### PR TITLE
add support for external sharing packages + add for hasadna maps daily summary

### DIFF
--- a/covid19israel.source-spec.yaml
+++ b/covid19israel.source-spec.yaml
@@ -65,12 +65,12 @@ maps_generate_daily_summary:
   dependencies:
     - bayesian_correction
   module: src.utils.maps.generate_daily_summary
-#  external_sharing_packages:
-#    - package_path: out/external_sharing/HASADNA/datapackage.json
-#      publish_targets:
-#        - github_repo: hasadna/avid-covider-raw-data
-#          deploy_key: hasadna_avid_covider_raw_data
-#          files:
-#            daily_summary: "input/{POSTERIOR_DATE}.csv"
-#            cities_geojson: "geo/cities.geojson"
-#            neighborhoods_geojson: "geo/neighborhoods.geojson"
+  external_sharing_packages:
+    - package_path: out/external_sharing/HASADNA/datapackage.json
+      publish_targets:
+        - github_repo: hasadna/avid-covider-raw-data
+          deploy_key: hasadna_avid_covider_raw_data
+          files:
+            daily_summary: "input/{POSTERIOR_DATE}.csv"
+            cities_geojson: "geo/cities.geojson"
+            neighborhoods_geojson: "geo/neighborhoods.geojson"

--- a/datapackage_pipelines_covid19israel/__init__.py
+++ b/datapackage_pipelines_covid19israel/__init__.py
@@ -26,10 +26,18 @@ class Generator(GeneratorBase):
             if not source_pipeline.get("output-dir"):
                 source_pipeline["output-dir"] = "data/%s" % pipeline_id
             source_pipeline['raise-exceptions'] = True
+            external_sharing_packages = source_pipeline.pop("external_sharing_packages", None)
             pipeline['pipeline'] = [
                 {
                     "flow": "avid_covider_pipelines.run_covid19_israel",
                     "parameters": source_pipeline
                 }
             ]
+            if external_sharing_packages:
+                pipeline["pipeline"].append({
+                    "flow": "datapackage_pipelines_covid19israel.publish_external_sharing_packages",
+                    "parameters": {
+                        "packages": external_sharing_packages
+                    }
+                })
             yield os.path.join(source_dir, pipeline_id), pipeline

--- a/datapackage_pipelines_covid19israel/publish_external_sharing_packages.py
+++ b/datapackage_pipelines_covid19israel/publish_external_sharing_packages.py
@@ -1,0 +1,84 @@
+import os
+import json
+from dataflows import Flow, update_resource, printer
+import tempfile
+import subprocess
+import shutil
+import logging
+from avid_covider_pipelines.utils import get_hash
+
+
+def flow(parameters, *_):
+
+    def _process_packages():
+        for package in parameters.get("packages", []):
+            with open(os.path.join("..", "COVID19-ISRAEL", package["package_path"])) as f:
+                package_descriptor = json.load(f)
+            resources = {
+                resource["name"]: resource
+                for resource in package_descriptor["resources"]
+            }
+            for publish_target in package["publish_targets"]:
+                assert "github_repo" in publish_target and "deploy_key" in publish_target and "files" in publish_target
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    source_deploy_key_file = os.environ["DEPLOY_KEY_FILE_" + publish_target["deploy_key"]]
+                    deploy_key_file = os.path.join(tmpdir, "deploy_key")
+                    shutil.copyfile(source_deploy_key_file, deploy_key_file)
+                    os.chmod(deploy_key_file, 400)
+                    gitenv = {
+                        **os.environ,
+                        "GIT_SSH_COMMAND": "ssh -i %s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" % deploy_key_file
+                    }
+                    branch = publish_target.get("branch", "master")
+                    repodir = os.path.join(tmpdir, "repo")
+                    subprocess.check_call(["git", "clone", "--depth", "1", "--branch", branch, "git@github.com:hasadna/avid-covider-raw-data.git", repodir], env=gitenv)
+                    subprocess.check_call(["git", "config", "user.name", "avid-covider-pipelines"], cwd=repodir)
+                    subprocess.check_call(["git", "config", "user.email", "avid-covider-pipelines@localhost"], cwd=repodir)
+                    num_added = 0
+                    for resource_name, target_path_template in publish_target["files"].items():
+                        target_path = target_path_template.format(**package_descriptor)
+                        target_fullpath = os.path.join(repodir, target_path)
+                        if os.path.exists(target_fullpath) and get_hash(target_fullpath) == resources[resource_name]["hash"]:
+                            logging.info("File is not changed: %s" % resources[resource_name]["path"])
+                            continue
+                        source_path = os.path.join("..", "COVID19-ISRAEL", resources[resource_name]["path"])
+                        logging.info("%s: %s --> %s" % (resource_name, source_path, target_fullpath))
+                        shutil.copyfile(source_path, target_fullpath)
+                        subprocess.check_call(["git", "add", target_path], cwd=repodir)
+                        num_added += 1
+                    if num_added > 0:
+                        logging.info("Committing %s changes" % num_added)
+                        subprocess.check_call(["git", "commit", "-m", "automated updated from hasadna/avid-covider-pipelines"], cwd=repodir)
+                        subprocess.check_call(["git", "push", "origin", branch], cwd=repodir, env=gitenv)
+                    else:
+                        logging.info("No changes to commit")
+            yield {"name": package_descriptor["name"], "datetime": package_descriptor["datetime"], "hash": package_descriptor["hash"]}
+
+    return Flow(
+        _process_packages(),
+        update_resource(-1, name="published_packages", path="published_packages.csv", **{"dpp:streaming": True}),
+        printer()
+    )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    flow({
+        "packages": [
+            {
+                "package_path": "out/external_sharing/HASADNA/datapackage.json",
+                "publish_targets": [
+                    {
+                        "github_repo": "hasadna/avid-covider-raw-data",
+                        "deploy_key": "hasadna_avid_covider_raw_data",
+                        "files": {
+                            "daily_summary": "input/{POSTERIOR_DATE}.csv",
+                            "cities_geojson": "geo/cities.geojson",
+                            "neighborhoods_geojson": "geo/neighborhoods.geojson"
+                        }
+                    }
+                ]
+
+            }
+        ]
+    }).process()


### PR DESCRIPTION
before merge - 

* wait for pipelines to complete successfully from previous merge
* update the pipelines deployment in k8s to update the secret (`./helm_upgrade_external_chart.sh avidcovider`