### PR TITLE
corona_data_collector: new fields for bot version 2.8.*

### DIFF
--- a/corona_data_collector/DBToFileWriter.py
+++ b/corona_data_collector/DBToFileWriter.py
@@ -1,4 +1,4 @@
-from corona_data_collector.config import answer_titles, values_to_convert, keys_to_convert, insulation_status_keys_to_convert
+from corona_data_collector.config import answer_titles, values_to_convert, keys_to_convert, insulation_status_keys_to_convert, values_force_integer, default_values
 from corona_data_collector.questionare_versions import get_version_columns
 
 
@@ -11,12 +11,12 @@ for orig_key, conv_key in keys_to_convert.items():
 
 def get_default_value(column_name, version):
     if column_name in get_version_columns(version):
-        return 0
+        return default_values.get(column_name, 0)
     if column_name in inverse_converted_keys:
         alternative_keys = inverse_converted_keys[column_name]
         for alt_key in alternative_keys:
             if alt_key in get_version_columns(version):
-                return 0
+                return default_values.get(column_name, 0)
     return ''
 
 
@@ -39,6 +39,12 @@ def collect_row(row, return_array=False, force_version=None):
 
 
 def convert_values(db_row, stats=None):
+    for key in values_force_integer:
+        if key in db_row and db_row[key] is not None:
+            try:
+                db_row[key] = int(db_row[key])
+            except Exception:
+                db_row[key] = 0
     for convert_key in keys_to_convert:
         if db_row.get(convert_key):
             db_row[keys_to_convert[convert_key]] = db_row[convert_key]

--- a/corona_data_collector/config.py
+++ b/corona_data_collector/config.py
@@ -85,6 +85,7 @@ answer_titles = {
     'symptoms_smell_taste_loss': 'symptoms_smell_taste_loss',
     'symptoms_other': 'symptoms_other',
     "abdominal_pain": "symptom_abdominal_pain",
+    "lack_of_appetite_or_skipping_meals": "symptom_lack_of_appetite_skipping_meals",
     'exposure_met_people': 'exposure_met_people',
     'flatmates': 'flatmates',
     'flatmates_over_70': 'flatmates_over_70',

--- a/corona_data_collector/config.py
+++ b/corona_data_collector/config.py
@@ -111,7 +111,8 @@ answer_titles = {
     "work_outside": "work_outside",
     "work_outside_avg_weekly_hours": "work_outside_avg_weekly_hours",
     "work_outside_city_town": "workplace_city_town",
-    "work_outside_street": "workplace_street"
+    "work_outside_street": "workplace_street",
+    "assisted_living": "assisted_living"
 }
 # make sure there aren't any duplicate columns
 assert len(set(answer_titles.values())) == len(answer_titles)
@@ -181,6 +182,11 @@ values_to_convert = {
     'medical_staff_member': {
         'false': 0,
         'true': 1
+    },
+    "assisted_living": {
+        'false': 0,
+        'true': 1,
+        'no_response': 2
     }
 }
 for field, values in values_to_convert.items():

--- a/corona_data_collector/config.py
+++ b/corona_data_collector/config.py
@@ -108,6 +108,10 @@ answer_titles = {
     "main_uid": "main_uid",
     "uid": "uid",
     "num_aliases": "num_aliases",
+    "work_outside": "work_outside",
+    "work_outside_avg_weekly_hours": "work_outside_avg_weekly_hours",
+    "work_outside_city_town": "workplace_city_town",
+    "work_outside_street": "workplace_street"
 }
 # make sure there aren't any duplicate columns
 assert len(set(answer_titles.values())) == len(answer_titles)
@@ -183,3 +187,12 @@ for field, values in values_to_convert.items():
     values_to_convert[field] = {
         k.lower(): v for k, v in values.items()
     }
+
+
+values_force_integer = ["work_outside_avg_weekly_hours"]
+
+
+default_values = {
+    "work_outside_street": "",
+    "work_outside_city_town": ""
+}

--- a/corona_data_collector/config.py
+++ b/corona_data_collector/config.py
@@ -84,6 +84,7 @@ answer_titles = {
     'symptoms_tiredness_or_fatigue': 'symptoms_tiredness_or_fatigue',
     'symptoms_smell_taste_loss': 'symptoms_smell_taste_loss',
     'symptoms_other': 'symptoms_other',
+    "abdominal_pain": "symptom_abdominal_pain",
     'exposure_met_people': 'exposure_met_people',
     'flatmates': 'flatmates',
     'flatmates_over_70': 'flatmates_over_70',

--- a/corona_data_collector/export_corona_bot_answers.py
+++ b/corona_data_collector/export_corona_bot_answers.py
@@ -105,7 +105,7 @@ def flow(parameters, *_):
         # print(row)
         try:
             data_dict = {k: json.loads(v) for k, v in row.items()
-                         if k not in ["__id", "__created", "lat", "lng", "address_street_accurate"]}
+                         if k not in ["__id", "__created", "lat", "lng", "address_street_accurate", "workplace_lat", "workplace_lng", "workplace_street_accurate"]}
         except TypeError:
             logging.info(row)
             raise
@@ -115,6 +115,9 @@ def flow(parameters, *_):
         data_dict["lat"] = row["lat"]
         data_dict["lng"] = row["lng"]
         data_dict["address_street_accurate"] = row["address_street_accurate"]
+        data_dict["workplace_lat"] = row.get("workplace_lat")
+        data_dict["workplace_lng"] = row.get("workplace_lng")
+        data_dict["workplace_street_accurate"] = row.get("workplace_street_accurate")
         # print(data_dict)
         fixed_row = convert_values(data_dict, stats)
         if fixed_row is None:
@@ -131,6 +134,9 @@ def flow(parameters, *_):
         output_row['lat'] = str(row['lat'])
         output_row['lng'] = str(row['lng'])
         output_row['address_street_accurate'] = str(row['address_street_accurate'])
+        output_row['workplace_lat'] = str(row.get('workplace_lat', ""))
+        output_row['workplace_lng'] = str(row.get('workplace_lng', ""))
+        output_row['workplace_street_accurate'] = str(row.get('workplace_street_accurate', ""))
         return {"output_row": output_row, "created": row['__created']}
 
     def _dump_row(row):
@@ -145,7 +151,7 @@ def flow(parameters, *_):
             cur_csv['filename'] = cur_csv['file'].name
             logging.info("Writing to temp file for %s_%s_%s" % (day, month, year))
             csv_temp_files[cur_csv['filename']] = "corona_bot_answers_%s_%s_%s_with_coords.csv" % (day, month, year)
-            cur_csv['writer'] = csv.DictWriter(cur_csv['file'], output_keys + ["lat", "lng", "address_street_accurate"])
+            cur_csv['writer'] = csv.DictWriter(cur_csv['file'], output_keys + ["lat", "lng", "address_street_accurate"] + ["workplace_lat", "workplace_lng", "workplace_street_accurate"])
             cur_csv['writer'].writeheader()
         cur_csv['writer'].writerow(row['output_row'])
 

--- a/corona_data_collector/load_from_db.py
+++ b/corona_data_collector/load_from_db.py
@@ -42,6 +42,8 @@ def flow(parameters, *_):
         logging.info("Loading all records from DB")
         where = ""
     for id, created, data in engine.execute("select id, created, data from reports%s order by id" % where):
+        if parameters.get("filter_db_row_callback"):
+            id, created, data = parameters["filter_db_row_callback"](id, created, data)
         if not data or not isinstance(data, dict):
             stats['invalid data'] += 1
             continue

--- a/corona_data_collector/questionare_versions.py
+++ b/corona_data_collector/questionare_versions.py
@@ -270,7 +270,7 @@ questionare_versions = {
               'symptoms_dry_cough', 'symptoms_headache', 'symptoms_moist_cough', 'symptoms_muscles_pain',
               'symptoms_nausea_and_vomiting', 'symptoms_smell_taste_loss', 'symptoms_sore_throat',
               'symptoms_tiredness_or_fatigue', 'temperature', 'toplevel_symptoms_cough', 'toplevel_symptoms_pains',
-              'abdominal_pain',
+              'abdominal_pain', "lack_of_appetite_or_skipping_meals",
               'version'},
 }
 

--- a/corona_data_collector/questionare_versions.py
+++ b/corona_data_collector/questionare_versions.py
@@ -271,6 +271,7 @@ questionare_versions = {
               'symptoms_nausea_and_vomiting', 'symptoms_smell_taste_loss', 'symptoms_sore_throat',
               'symptoms_tiredness_or_fatigue', 'temperature', 'toplevel_symptoms_cough', 'toplevel_symptoms_pains',
               'abdominal_pain', "lack_of_appetite_or_skipping_meals",
+              "work_outside", "work_outside_avg_weekly_hours", "work_outside_city_town", "work_outside_street"
               'version'},
 }
 

--- a/corona_data_collector/questionare_versions.py
+++ b/corona_data_collector/questionare_versions.py
@@ -258,6 +258,20 @@ questionare_versions = {
               'symptoms_nausea_and_vomiting', 'symptoms_smell_taste_loss', 'symptoms_sore_throat',
               'symptoms_tiredness_or_fatigue', 'temperature', 'toplevel_symptoms_cough', 'toplevel_symptoms_pains',
               'version'},
+    '2.8.*': {'age', 'alias', 'city_town', 'covid19_check_date','covid19_check_result','dateFirstReport',              'diagnosed_location', 'engagementSource',
+              'exposure_status', 'general_feeling', 'insulation_exposure_date', 'insulation_patient_number',
+              'insulation_reason', 'insulation_returned_from_abroad_date', 'insulation_start_date', 'layout', 'locale',
+              'medical_staff_member', 'met_above_18', 'met_under_18', 'notificationsEnabled', 'numPreviousReports',
+              'precondition_chronic_cancer', 'precondition_chronic_diabetes', 'precondition_chronic_hypertension',
+              'precondition_chronic_immune_system_suppression', 'precondition_chronic_ischemic_heart_disease_or_stroke',
+              'precondition_chronic_kidney_failure', 'precondition_chronic_lung_disease', 'precondition_smoking',
+              'preconditions_received', 'served_public_last_fortnight', 'sex', 'street', 'symptoms_breath_shortness',
+              'symptoms_chills', 'symptoms_clogged_nose', 'symptoms_confusion', 'symptoms_diarrhea',
+              'symptoms_dry_cough', 'symptoms_headache', 'symptoms_moist_cough', 'symptoms_muscles_pain',
+              'symptoms_nausea_and_vomiting', 'symptoms_smell_taste_loss', 'symptoms_sore_throat',
+              'symptoms_tiredness_or_fatigue', 'temperature', 'toplevel_symptoms_cough', 'toplevel_symptoms_pains',
+              'abdominal_pain',
+              'version'},
 }
 
 

--- a/corona_data_collector/tests/common.py
+++ b/corona_data_collector/tests/common.py
@@ -1,7 +1,7 @@
 import logging
 
 
-def test_corona_bot_answers(actual_row_callback, expected_data):
+def test_corona_bot_answers(actual_row_callback, expected_data, extra_row_test_callback=None):
 
     def _test(rows):
         logging.info("Testing corona_bot_answers...")
@@ -10,6 +10,8 @@ def test_corona_bot_answers(actual_row_callback, expected_data):
             expected_row = expected_data[row["id"]]
             actual_row = [rows.res.name, *actual_row_callback(row)]
             assert expected_row == actual_row, "%s: %s" % (row["id"], actual_row)
+            if extra_row_test_callback:
+                extra_row_test_callback(row)
         logging.info("Testing completed successfully")
 
     return _test

--- a/corona_data_collector/tests/test_asisted_living.py
+++ b/corona_data_collector/tests/test_asisted_living.py
@@ -1,0 +1,76 @@
+import random
+import logging
+from corona_data_collector import load_from_db, add_gps_coordinates, export_corona_bot_answers
+from avid_covider_pipelines.utils import get_parameters_from_pipeline_spec
+from dataflows import printer, Flow, load
+from .common import test_corona_bot_answers
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+def _mock_assisted_living(id, created, data):
+    if id == 180075:
+        logging.info("Mocking version 2.8 for id 600304 with assisted_living = no_response")
+        data["assisted_living"] = "no_response"
+        data["version"] = "2.8.0"
+    elif id == 600304:
+        logging.info("Mocking version 2.8 for id 600304 with assisted_living = true")
+        data["assisted_living"] = True
+        data["version"] = "2.8.0"
+    elif id == 676580:
+        logging.info("Mocking version 2.8 for id 676580 with assisted_living = false")
+        data["assisted_living"] = False
+        data["version"] = "2.8.0"
+    elif id == 676581:
+        logging.info("Mocking version 2.8 for id 600304 with assisted_living = 'true'")
+        data["assisted_living"] = "true"
+        data["version"] = "2.8.0"
+    elif id == 701508:
+        logging.info("Mocking version 2.8 for id 676580 with assisted_living = 'false'")
+        data["assisted_living"] = "false"
+        data["version"] = "2.8.0"
+    return id, created, data
+
+
+Flow(
+    load_from_db.flow({
+        "where": "id in (94, 180075, 600304, 600895, 676580, 676581, 701508)",
+        "filter_db_row_callback": _mock_assisted_living
+    }),
+    add_gps_coordinates.flow({
+        "source_fields": get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["source_fields"],
+        "get-coords-callback": lambda street, city: (random.uniform(29, 34), random.uniform(34, 36), int(street != city))
+    }),
+    export_corona_bot_answers.flow({
+        "destination_output": "data/corona_data_collector/destination_output"
+    }),
+    printer(fields=[
+        "__id", "__created", "version", "assisted_living"
+    ]),
+).process()
+Flow(
+    load("data/corona_data_collector/destination_output/corona_bot_answers_22_3_2020_with_coords.csv"),
+    load("data/corona_data_collector/destination_output/corona_bot_answers_25_3_2020_with_coords.csv"),
+    load("data/corona_data_collector/destination_output/corona_bot_answers_20_4_2020_with_coords.csv"),
+    load("data/corona_data_collector/destination_output/corona_bot_answers_29_4_2020_with_coords.csv"),
+    load("data/corona_data_collector/destination_output/corona_bot_answers_2_5_2020_with_coords.csv"),
+    test_corona_bot_answers(
+        lambda row: (str(row["questionare_version"]), str(row["assisted_living"])),
+        {
+            "94": ["corona_bot_answers_22_3_2020_with_coords", "0.1.0", ""],
+            "180075": ["corona_bot_answers_25_3_2020_with_coords", "2.8.0", "2"],
+            "600304": ["corona_bot_answers_20_4_2020_with_coords", "2.8.0", "1"],
+            "600895": ["corona_bot_answers_20_4_2020_with_coords", "2.6.0", ""],
+            "676580": ["corona_bot_answers_29_4_2020_with_coords", "2.8.0", "0"],
+            "676581": ["corona_bot_answers_29_4_2020_with_coords", "2.8.0", "1"],
+            "701508": ["corona_bot_answers_2_5_2020_with_coords", "2.8.0", "0"],
+        }
+    ),
+    printer(fields=[
+        "timestamp", "id", "questionare_version", "assisted_living"
+    ])
+).process()
+
+
+logging.info("Great Success!")

--- a/corona_data_collector/tests/test_flow.py
+++ b/corona_data_collector/tests/test_flow.py
@@ -24,6 +24,53 @@ def _mock_gender_other(rows):
             yield row
 
 
+def _mock_version_28(id, created, data):
+    if 640000 <= id <= 640020:
+        logging.info("Mocking version 2.8 for ids 640000 to 640020: "
+                     "assisted_living = no_response , "
+                     "abdominal_pain = true , "
+                     "lack_of_appetite_or_skipping_meals = false , "
+                     "work_outside = no")
+        data["assisted_living"] = "no_response"
+        data["abdominal_pain"] = True
+        data["lack_of_appetite_or_skipping_meals"] = False
+        data["work_outside"] = False
+        data["version"] = "2.8.0"
+    elif 640021 <= id <= 640040:
+        logging.info("Mocking version 2.8 for ids 640021 to 640040: "
+                     "assisted_living = true , "
+                     "abdominal_pain = false , "
+                     "lack_of_appetite_or_skipping_meals = true , "
+                     "work_outside = yes + full details")
+        data["assisted_living"] = True
+        data["abdominal_pain"] = False
+        data["lack_of_appetite_or_skipping_meals"] = True
+        data["work_outside"] = True
+        data["work_outside_avg_weekly_hours"] = 3
+        data["work_outside_city_town"] = "תל אביב"
+        data["work_outside_street"] = "הרצל"
+        data["version"] = "2.8.0"
+    elif 640041 <= id <= 640060:
+        logging.info("Mocking version 2.8 for ids 640041 to 640060: "
+                     "assisted_living = false , "
+                     "work_outside = yes + minimal details")
+        data["assisted_living"] = False
+        data["work_outside"] = True
+        data["work_outside_avg_weekly_hours"] = 55
+        data["version"] = "2.8.0"
+    elif 640061 <= id <= 640080:
+        logging.info("Mocking version 2.8 for ids 640061 to 640080: "
+                     "assisted_living = 'true'")
+        data["assisted_living"] = "true"
+        data["version"] = "2.8.0"
+    elif 640081 <= id <= 640100:
+        logging.info("Mocking version 2.8 for ids 640081 to 640100: "
+                     "assisted_living = 'false'")
+        data["assisted_living"] = "false"
+        data["version"] = "2.8.0"
+    return id, created, data
+
+
 def main():
     with tempfile.TemporaryDirectory() as tempdir:
         with open(os.path.join(tempdir, ".netrc"), "w") as f:
@@ -48,7 +95,8 @@ def main():
                 }
             }),
             load_from_db.flow({
-                "where": "(id > 500 and id < 1000) or (id > 180000 and id < 185000) or (id > 600000 and id < 601000) or (id > 640000 and id < 641000) or (id > 670000)"
+                "where": "(id > 500 and id < 1000) or (id > 180000 and id < 185000) or (id > 600000 and id < 601000) or (id > 640000 and id < 641000) or (id > 670000)",
+                "filter_db_row_callback": _mock_version_28
             }),
             _mock_gender_other,
             add_gps_coordinates.flow({

--- a/corona_data_collector/tests/test_flow.py
+++ b/corona_data_collector/tests/test_flow.py
@@ -100,26 +100,8 @@ def main():
             }),
             _mock_gender_other,
             add_gps_coordinates.flow({
-                "source_fields": {
-                    "db": {
-                        "street": "street",
-                        "city_town": "city",
-                    },
-                    "google": {
-                        "Street": "street",
-                        "Город проживания": "street",
-                        "City": "city",
-                        "Улица": "city",
-                    },
-                    "hebrew_google": {
-                        "עיר / ישוב מגורים": "city",
-                        "עיר / יישוב מגורים": "city",
-                        "רחוב מגורים": "street",
-                    },
-                    "maccabi": {
-                        "yishuv": "city",
-                    }
-                },
+                "source_fields": utils.get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["source_fields"],
+                "workplace_source_fields": utils.get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["workplace_source_fields"],
                 "dump_to_path": "data/corona_data_collector/with_gps_data",
                 "gps_datapackage_path": "data/corona_data_collector/gps_data_cache",
                 "get-coords-callback": lambda street, city: (random.uniform(29, 34), random.uniform(34, 36), int(street != city))

--- a/corona_data_collector/tests/test_symptom_abdominal_pain.py
+++ b/corona_data_collector/tests/test_symptom_abdominal_pain.py
@@ -1,0 +1,64 @@
+import random
+import logging
+from corona_data_collector import load_from_db, add_gps_coordinates, export_corona_bot_answers
+from avid_covider_pipelines.utils import get_parameters_from_pipeline_spec
+from dataflows import printer, Flow, load
+from .common import test_corona_bot_answers
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+def _mock_abdominal_pain(id, created, data):
+    if id == 600304:
+        logging.info("Mocking version 2.8 for id 600304 with abdominal_pain = true")
+        data["abdominal_pain"] = True
+        data["version"] = "2.8.0"
+    elif id == 676580:
+        logging.info("Mocking version 2.8 for id 676580 with abdominal_pain = false")
+        data["abdominal_pain"] = False
+        data["version"] = "2.8.0"
+    return id, created, data
+
+
+Flow(
+    load_from_db.flow({
+        "where": "id in (94, 180075, 600304, 600895, 676580, 676581, 701508)",
+        "filter_db_row_callback": _mock_abdominal_pain
+    }),
+    add_gps_coordinates.flow({
+        "source_fields": get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["source_fields"],
+        "get-coords-callback": lambda street, city: (random.uniform(29, 34), random.uniform(34, 36), int(street != city))
+    }),
+    export_corona_bot_answers.flow({
+        "destination_output": "data/corona_data_collector/destination_output"
+    }),
+    printer(fields=[
+        "__id", "__created", "version", "abdominal_pain"
+    ]),
+).process()
+Flow(
+    load("data/corona_data_collector/destination_output/corona_bot_answers_22_3_2020_with_coords.csv"),
+    load("data/corona_data_collector/destination_output/corona_bot_answers_25_3_2020_with_coords.csv"),
+    load("data/corona_data_collector/destination_output/corona_bot_answers_20_4_2020_with_coords.csv"),
+    load("data/corona_data_collector/destination_output/corona_bot_answers_29_4_2020_with_coords.csv"),
+    load("data/corona_data_collector/destination_output/corona_bot_answers_2_5_2020_with_coords.csv"),
+    test_corona_bot_answers(
+        lambda row: (str(row["symptom_abdominal_pain"]), str(row["questionare_version"])),
+        {
+            "94": ["corona_bot_answers_22_3_2020_with_coords", "", "0.1.0"],
+            "180075": ["corona_bot_answers_25_3_2020_with_coords", "", "1.0.1"],
+            "600304": ["corona_bot_answers_20_4_2020_with_coords", "1", "2.8.0"],
+            "600895": ["corona_bot_answers_20_4_2020_with_coords", "", "2.6.0"],
+            "676580": ["corona_bot_answers_29_4_2020_with_coords", "0", "2.8.0"],
+            "676581": ["corona_bot_answers_29_4_2020_with_coords", "", "2.7.4"],
+            "701508": ["corona_bot_answers_2_5_2020_with_coords", "", "2.7.6"],
+        }
+    ),
+    printer(fields=[
+        "timestamp", "id", "symptom_abdominal_pain", "questionare_version"
+    ])
+).process()
+
+
+logging.info("Great Success!")

--- a/corona_data_collector/tests/test_v2_8_symptoms.py
+++ b/corona_data_collector/tests/test_v2_8_symptoms.py
@@ -11,12 +11,14 @@ logging.basicConfig(level=logging.INFO)
 
 def _mock_abdominal_pain(id, created, data):
     if id == 600304:
-        logging.info("Mocking version 2.8 for id 600304 with abdominal_pain = true")
+        logging.info("Mocking version 2.8 for id 600304 with abdominal_pain = true , lack_of_appetite_or_skipping_meals = false")
         data["abdominal_pain"] = True
+        data["lack_of_appetite_or_skipping_meals"] = False
         data["version"] = "2.8.0"
     elif id == 676580:
-        logging.info("Mocking version 2.8 for id 676580 with abdominal_pain = false")
+        logging.info("Mocking version 2.8 for id 676580 with abdominal_pain = false , lack_of_appetite_or_skipping_meals = true")
         data["abdominal_pain"] = False
+        data["lack_of_appetite_or_skipping_meals"] = True
         data["version"] = "2.8.0"
     return id, created, data
 
@@ -34,7 +36,7 @@ Flow(
         "destination_output": "data/corona_data_collector/destination_output"
     }),
     printer(fields=[
-        "__id", "__created", "version", "abdominal_pain"
+        "__id", "__created", "version", "abdominal_pain", "lack_of_appetite_or_skipping_meals"
     ]),
 ).process()
 Flow(
@@ -44,19 +46,19 @@ Flow(
     load("data/corona_data_collector/destination_output/corona_bot_answers_29_4_2020_with_coords.csv"),
     load("data/corona_data_collector/destination_output/corona_bot_answers_2_5_2020_with_coords.csv"),
     test_corona_bot_answers(
-        lambda row: (str(row["symptom_abdominal_pain"]), str(row["questionare_version"])),
+        lambda row: (str(row["symptom_abdominal_pain"]), str(row["symptom_lack_of_appetite_skipping_meals"]), str(row["questionare_version"])),
         {
-            "94": ["corona_bot_answers_22_3_2020_with_coords", "", "0.1.0"],
-            "180075": ["corona_bot_answers_25_3_2020_with_coords", "", "1.0.1"],
-            "600304": ["corona_bot_answers_20_4_2020_with_coords", "1", "2.8.0"],
-            "600895": ["corona_bot_answers_20_4_2020_with_coords", "", "2.6.0"],
-            "676580": ["corona_bot_answers_29_4_2020_with_coords", "0", "2.8.0"],
-            "676581": ["corona_bot_answers_29_4_2020_with_coords", "", "2.7.4"],
-            "701508": ["corona_bot_answers_2_5_2020_with_coords", "", "2.7.6"],
+            "94": ["corona_bot_answers_22_3_2020_with_coords", "", "", "0.1.0"],
+            "180075": ["corona_bot_answers_25_3_2020_with_coords", "", "", "1.0.1"],
+            "600304": ["corona_bot_answers_20_4_2020_with_coords", "1", "0", "2.8.0"],
+            "600895": ["corona_bot_answers_20_4_2020_with_coords", "", "", "2.6.0"],
+            "676580": ["corona_bot_answers_29_4_2020_with_coords", "0", "1", "2.8.0"],
+            "676581": ["corona_bot_answers_29_4_2020_with_coords", "", "", "2.7.4"],
+            "701508": ["corona_bot_answers_2_5_2020_with_coords", "", "", "2.7.6"],
         }
     ),
     printer(fields=[
-        "timestamp", "id", "symptom_abdominal_pain", "questionare_version"
+        "timestamp", "id", "symptom_abdominal_pain", "symptom_lack_of_appetite_skipping_meals", "questionare_version"
     ])
 ).process()
 

--- a/corona_data_collector/tests/test_work_outside_questions.py
+++ b/corona_data_collector/tests/test_work_outside_questions.py
@@ -1,0 +1,97 @@
+import random
+import logging
+from corona_data_collector import load_from_db, add_gps_coordinates, export_corona_bot_answers
+from avid_covider_pipelines.utils import get_parameters_from_pipeline_spec
+from dataflows import printer, Flow, load
+from .common import test_corona_bot_answers
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+def _mock_work_outside(id, created, data):
+    if id == 600304:
+        logging.info("Mocking version 2.8 for id 600304 with work_outside = no")
+        data["work_outside"] = False
+        data["version"] = "2.8.0"
+    elif id == 676580:
+        logging.info("Mocking version 2.8 for id 676580 with work_outside = yes + full details")
+        data["work_outside"] = True
+        data["work_outside_avg_weekly_hours"] = 3
+        data["work_outside_city_town"] = "תל אביב"
+        data["work_outside_street"] = "הרצל"
+        data["version"] = "2.8.0"
+    elif id == 676581:
+        logging.info("Mocking version 2.8 for id 676581 with work_outside = yes + minimal details")
+        data["work_outside"] = True
+        data["work_outside_avg_weekly_hours"] = 55
+        data["version"] = "2.8.0"
+    elif id == 180075:
+        logging.info("Mocking version 2.8 for id 180075 with work_outside = yes + invalid details")
+        data["work_outside"] = True
+        data["work_outside_avg_weekly_hours"] = "foobar"
+        data["work_outside_city_town"] = 55
+        data["work_outside_street"] = 44
+        data["version"] = "2.8.0"
+    return id, created, data
+
+
+Flow(
+    load_from_db.flow({
+        "where": "id in (94, 180075, 600304, 600895, 676580, 676581, 701508)",
+        "filter_db_row_callback": _mock_work_outside
+    }),
+    add_gps_coordinates.flow({
+        "source_fields": get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["source_fields"],
+        "workplace_source_fields": get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["workplace_source_fields"],
+        "get-coords-callback": lambda street, city: (random.uniform(29, 34), random.uniform(34, 36), int(street != city))
+    }),
+    export_corona_bot_answers.flow({
+        "destination_output": "data/corona_data_collector/destination_output"
+    }),
+    printer(fields=[
+        "__id", "__created", "version", "work_outside", "work_outside_avg_weekly_hours", "work_outside_city_town",
+        "work_outside_street", "workplace_lat", "workplace_lng", "workplace_street_accurate"
+    ]),
+).process()
+
+
+def _test_workplace_lat_lng(row):
+    if row["id"] in ["180075", "676580"]:
+        assert row["workplace_lat"] and row["workplace_lng"], (row["id"], row["workplace_lat"], row["workplace_lng"])
+    else:
+        assert row["workplace_lat"] == "0" and row["workplace_lng"] == "0", (row["id"], row["workplace_lat"], row["workplace_lng"])
+
+
+Flow(
+    load("data/corona_data_collector/destination_output/corona_bot_answers_22_3_2020_with_coords.csv"),
+    load("data/corona_data_collector/destination_output/corona_bot_answers_25_3_2020_with_coords.csv"),
+    load("data/corona_data_collector/destination_output/corona_bot_answers_20_4_2020_with_coords.csv"),
+    load("data/corona_data_collector/destination_output/corona_bot_answers_29_4_2020_with_coords.csv"),
+    load("data/corona_data_collector/destination_output/corona_bot_answers_2_5_2020_with_coords.csv"),
+    test_corona_bot_answers(
+        lambda row: (
+            str(row["questionare_version"]), str(row["work_outside"]), str(row["work_outside_avg_weekly_hours"]),
+            str(row["workplace_city_town"]), str(row["workplace_street"]),
+            str(row["workplace_street_accurate"]),
+        ),
+        {
+                                                                       #  work_outside    hours    city_town    street    accurate
+            "94": ["corona_bot_answers_22_3_2020_with_coords", "0.1.0",       "",         "",      "",          "",       "0"     ],
+            "180075": ["corona_bot_answers_25_3_2020_with_coords", "2.8.0",   "1",        "0",     "55",        "44",     "1"     ],
+            "600304": ["corona_bot_answers_20_4_2020_with_coords", "2.8.0",   "0",        "0",     "",          "",       "0"     ],
+            "600895": ["corona_bot_answers_20_4_2020_with_coords", "2.6.0",   "",         "",      "",          "",       "0"     ],
+            "676580": ["corona_bot_answers_29_4_2020_with_coords", "2.8.0",   "1",        "3",     "תל אביב",   "הרצל",   "1"     ],
+            "676581": ["corona_bot_answers_29_4_2020_with_coords", "2.8.0",   "1",        "55",    "",          "",       "0"     ],
+            "701508": ["corona_bot_answers_2_5_2020_with_coords", "2.7.6",    "",          "",     "",          "",       "0"    ],
+        },
+        _test_workplace_lat_lng
+    ),
+    printer(fields=[
+        "timestamp", "id", "questionare_version", "work_outside", "work_outside_avg_weekly_hours",
+        "workplace_city_town", "workplace_street", "workplace_lat", "workplace_lng", "workplace_street_accurate"
+    ])
+).process()
+
+
+logging.info("Great Success!")

--- a/pipeline-spec.yaml
+++ b/pipeline-spec.yaml
@@ -68,6 +68,12 @@ corona_data_collector:
             "yishuv": "city",
           }
         }
+        workplace_source_fields: {
+          "db": {
+            "work_outside_street": "street",
+            "work_outside_city_town": "city"
+          }
+        }
         dump_to_path: data/corona_data_collector/with_gps_data
         # gps_data: data/corona_data_collector/gps_data.json
         gps_datapackage_path: data/corona_data_collector/gps_data_cache


### PR DESCRIPTION
**do not merge - actual version number might change and there might be small changes to fields**

added fields for v2.8.* to corona_bot_answers csv:
* `symptom_abdominal_pain` = (`"1"`: true, `"0"`: false, `""`: version < 2.8)
* `symptom_lack_of_appetite_skipping_meals` = (`"1"`: true, `"0"`: false, `""`: version < 2.8)
* `work_outside` = (`"1"`: true, `"0"`: false, `""`: version < 2.8)
* `work_outside_avg_weekly_hours` = (`0`: no work_outside, `>0`: hours, `""`: version < 2.8)
* `workplace_city_town` = (`""`: does not work_outside or version < 2.8, `"string"`: city)
* `workplace_street` = (`""`: does not work_outside or version < 2.8, `"string"`: street)
* `workplace_lat` = (`0`: does not work_outside or version < 2.8, `>0`: lat of workplace)
* `workplace_lng` = (`0`: does not work_outside or version < 2.8, `>0`: lng of workplace)
* `workplace_street_accurate` = (`0`: does not work_outside / version < 2.8 / not street accurate, `1`: street accurate)
* `assisted_living` = (`0`: false, `1`: true, `2`: does not want to respond, `""`: version<2.8)