### PR TITLE
Fixes and tests for v3.0.0 after release

### DIFF
--- a/corona_data_collector/DBToFileWriter.py
+++ b/corona_data_collector/DBToFileWriter.py
@@ -1,7 +1,9 @@
 from corona_data_collector.config import (
     answer_titles, values_to_convert, keys_to_convert, insulation_status_keys_to_convert, values_force_integer, default_values,
+    values_datetime
 )
 from corona_data_collector.questionare_versions import get_version_columns
+import datetime
 
 
 inverse_converted_keys = {}
@@ -42,6 +44,12 @@ def collect_row(row, return_array=False, force_version=None):
 
 
 def convert_values(db_row, stats=None):
+    for key in values_datetime:
+        if key in db_row and db_row[key] is not None:
+            try:
+                db_row[key] = datetime.datetime.fromtimestamp(int(db_row[key])/1000).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+            except Exception:
+                db_row[key] = ""
     for key in values_force_integer:
         if key in db_row and db_row[key] is not None:
             try:

--- a/corona_data_collector/DBToFileWriter.py
+++ b/corona_data_collector/DBToFileWriter.py
@@ -47,7 +47,7 @@ def convert_values(db_row, stats=None):
     for key in values_datetime:
         if key in db_row and db_row[key] is not None:
             try:
-                db_row[key] = datetime.datetime.fromtimestamp(int(db_row[key])/1000).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+                db_row[key] = datetime.datetime.utcfromtimestamp(int(db_row[key])/1000).strftime("%Y-%m-%dT%H:%M:%S.000Z")
             except Exception:
                 db_row[key] = ""
     for key in values_force_integer:

--- a/corona_data_collector/config.py
+++ b/corona_data_collector/config.py
@@ -239,3 +239,8 @@ default_values = {
     "routine_wears_mask": 4,  # no_response
     "routine_wears_gloves": 4,  # no_response
 }
+
+
+values_datetime = [
+    "routine_last_asked"
+]

--- a/corona_data_collector/tests/common.py
+++ b/corona_data_collector/tests/common.py
@@ -1,4 +1,8 @@
 import logging
+from dataflows import Flow, load, printer
+from corona_data_collector import load_from_db, add_gps_coordinates, export_corona_bot_answers
+import random
+from avid_covider_pipelines.utils import get_parameters_from_pipeline_spec
 
 
 def test_corona_bot_answers(actual_row_callback, expected_data, extra_row_test_callback=None):
@@ -9,9 +13,119 @@ def test_corona_bot_answers(actual_row_callback, expected_data, extra_row_test_c
             yield row
             expected_row = expected_data[row["id"]]
             actual_row = [rows.res.name, *actual_row_callback(row)]
-            assert expected_row == actual_row, "%s: %s" % (row["id"], actual_row)
+            assert expected_row == actual_row, "%s: %s" % (row["id"], actual_row[1:])
             if extra_row_test_callback:
                 extra_row_test_callback(row)
         logging.info("Testing completed successfully")
 
     return _test
+
+
+def run_full_db_data_test(test_fields, test_data, dry_run=False, get_real_coords=False):
+    _test_data = {id: {} for id in test_data}
+
+    def _db_row_callback(id, created, data):
+        if id in test_data:
+            for db_field, assert_values in test_data[id].items():
+                if data.get(db_field) != assert_values[0]:
+                    msg = "Invalid data in db field %s id %s. expected=%s actual=%s" % (db_field, id, assert_values[0], data.get(db_field))
+                    if dry_run:
+                        logging.info(msg)
+                    else:
+                        raise AssertionError(msg)
+            logging.info("DB data is valid for id %s (validated %s fields)" % (id, len(test_data[id])))
+            _test_data[id]["created"] = created
+        return id, created, data
+
+    Flow(
+        load_from_db.flow({
+            "where": "id in (%s)" % ", ".join(map(str, test_data.keys())),
+            "filter_db_row_callback": _db_row_callback,
+        }),
+        add_gps_coordinates.flow({
+            "source_fields": get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["source_fields"],
+            "workplace_source_fields": get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["workplace_source_fields"],
+            **({
+                "get-coords-callback": lambda street, city: (random.uniform(29, 34), random.uniform(34, 36), int(street != city))
+            } if get_real_coords == False else {})
+        }),
+        export_corona_bot_answers.flow({
+            "destination_output": "data/corona_data_collector/destination_output"
+        }),
+        printer(fields=[
+            "__id", "__created", *test_fields.keys()
+        ]),
+    ).process()
+
+    _test_assertions = {
+        str(id): [
+            "corona_bot_answers_%s_with_coords" % _test_data[id]["created"].strftime("%-d_%-m_%Y"),
+        ]
+        for id in test_data
+    }
+
+    for db_field in sorted(test_fields.keys()):
+        for id, assertions in _test_assertions.items():
+            if len(test_data[int(id)][db_field]) == 1:
+                assertions.append(test_data[int(id)][db_field][0])
+            else:
+                assertions.append(test_data[int(id)][db_field][1])
+
+    def _test_corona_bot_answers_get_row(row):
+        return (
+            str(row[test_fields[db_field]])
+            for db_field in sorted(test_fields.keys())
+        )
+
+    try:
+        Flow(
+            *[
+                load(
+                    "data/corona_data_collector/destination_output/corona_bot_answers_%s_with_coords.csv" % created.strftime(
+                        "%-d_%-m_%Y"))
+                for created in set([data["created"] for data in _test_data.values()])
+            ],
+            test_corona_bot_answers(
+                _test_corona_bot_answers_get_row,
+                _test_assertions
+            ),
+            printer(fields=[
+                "timestamp", "id", *test_fields.values()
+            ])
+        ).process()
+    except AssertionError as e:
+        raise AssertionError(
+            str(e) + " fields: " + str([test_fields[db_field] for db_field in sorted(test_fields.keys())]))
+
+    logging.info("Great Success!")
+
+
+def get_db_test_row(version=None, field_name=None, value=None, where=None, show_fields=None):
+    if not where:
+        where = []
+        if version:
+            where.append("data->>'version' = '%s'" % version)
+        if field_name and value:
+            where.append("data->>'%s' = '%s'" % (field_name, value))
+        where = " and ".join(where)
+    if not show_fields:
+        if field_name:
+            show_fields = [field_name]
+        else:
+            show_fields = []
+    Flow(
+        load_from_db.flow({
+            "where": where,
+        }),
+        add_gps_coordinates.flow({
+            "source_fields": get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["source_fields"],
+            "workplace_source_fields": get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["workplace_source_fields"],
+            "get-coords-callback": lambda street, city: (random.uniform(29, 34), random.uniform(34, 36), int(street != city))
+        }),
+        export_corona_bot_answers.flow({
+            "destination_output": "data/corona_data_collector/destination_output"
+        }),
+        printer(fields=[
+            "__id", "__created", *show_fields
+        ]),
+    ).process()

--- a/corona_data_collector/tests/test_asisted_living.py
+++ b/corona_data_collector/tests/test_asisted_living.py
@@ -1,76 +1,43 @@
-import random
 import logging
-from corona_data_collector import load_from_db, add_gps_coordinates, export_corona_bot_answers
-from avid_covider_pipelines.utils import get_parameters_from_pipeline_spec
-from dataflows import printer, Flow, load
-from .common import test_corona_bot_answers
+from corona_data_collector.tests.common import run_full_db_data_test, get_db_test_row
 
 
 logging.basicConfig(level=logging.INFO)
 
 
-def _mock_assisted_living(id, created, data):
-    if id == 180075:
-        logging.info("Mocking version 3.0 for id 600304 with is_assisted_living = no_response")
-        data["is_assisted_living"] = "no_response"
-        data["version"] = "3.0.0"
-    elif id == 600304:
-        logging.info("Mocking version 3.0 for id 600304 with is_assisted_living = true")
-        data["is_assisted_living"] = True
-        data["version"] = "3.0.0"
-    elif id == 676580:
-        logging.info("Mocking version 3.0 for id 676580 with is_assisted_living = false")
-        data["is_assisted_living"] = False
-        data["version"] = "3.0.0"
-    elif id == 676581:
-        logging.info("Mocking version 3.0 for id 600304 with is_assisted_living = 'true'")
-        data["is_assisted_living"] = "true"
-        data["version"] = "3.0.0"
-    elif id == 701508:
-        logging.info("Mocking version 3.0 for id 676580 with is_assisted_living = 'false'")
-        data["is_assisted_living"] = "false"
-        data["version"] = "3.0.0"
-    return id, created, data
+TEST_FIELDS = {
+    # db field            corona_bot_answers field
+    "version":            "questionare_version",
+    "is_assisted_living": "assisted_living"
+}
+TEST_DATA = {
+    # id in DB:
+    #   "db field": ("value in db", "value_in_corona_bot_answers")
+    94: {
+        "version": ("0.1.0",),
+        "is_assisted_living": (None, "")
+    },
+    400000: {
+        "version": ("2.2.2",),
+        "is_assisted_living": (None, "")
+    },
+    732704: {
+        "version": ("3.0.0",),
+        "is_assisted_living": (None, "")
+    },
+    732705: {
+        "version": ("3.0.0",),
+        "is_assisted_living": (False, "0")
+    },
+    733451: {
+        "version": ("3.0.0",),
+        "is_assisted_living": ("no_response", "2")
+    },
+    733631: {
+        "version": ("3.0.0",),
+        "is_assisted_living": (True, "1")
+    },
+}
 
 
-Flow(
-    load_from_db.flow({
-        "where": "id in (94, 180075, 600304, 600895, 676580, 676581, 701508)",
-        "filter_db_row_callback": _mock_assisted_living
-    }),
-    add_gps_coordinates.flow({
-        "source_fields": get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["source_fields"],
-        "get-coords-callback": lambda street, city: (random.uniform(29, 34), random.uniform(34, 36), int(street != city))
-    }),
-    export_corona_bot_answers.flow({
-        "destination_output": "data/corona_data_collector/destination_output"
-    }),
-    printer(fields=[
-        "__id", "__created", "version", "is_assisted_living"
-    ]),
-).process()
-Flow(
-    load("data/corona_data_collector/destination_output/corona_bot_answers_22_3_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_25_3_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_20_4_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_29_4_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_2_5_2020_with_coords.csv"),
-    test_corona_bot_answers(
-        lambda row: (str(row["questionare_version"]), str(row["assisted_living"])),
-        {
-            "94": ["corona_bot_answers_22_3_2020_with_coords", "0.1.0", ""],
-            "180075": ["corona_bot_answers_25_3_2020_with_coords", "3.0.0", "2"],
-            "600304": ["corona_bot_answers_20_4_2020_with_coords", "3.0.0", "1"],
-            "600895": ["corona_bot_answers_20_4_2020_with_coords", "2.6.0", ""],
-            "676580": ["corona_bot_answers_29_4_2020_with_coords", "3.0.0", "0"],
-            "676581": ["corona_bot_answers_29_4_2020_with_coords", "3.0.0", "1"],
-            "701508": ["corona_bot_answers_2_5_2020_with_coords", "3.0.0", "0"],
-        }
-    ),
-    printer(fields=[
-        "timestamp", "id", "questionare_version", "assisted_living"
-    ])
-).process()
-
-
-logging.info("Great Success!")
+run_full_db_data_test(TEST_FIELDS, TEST_DATA)

--- a/corona_data_collector/tests/test_flow.py
+++ b/corona_data_collector/tests/test_flow.py
@@ -12,98 +12,98 @@ DOMAIN = os.environ["AVIDCOVIDER_PIPELINES_DATA_DOMAIN"]
 AUTH_USER, AUTH_PASSWORD = os.environ["AVIDCOVIDER_PIPELINES_AUTH"].split(" ")
 
 
-def _mock_gender_other(rows):
-    if rows.res.name == "db_data":
-        logging.info("Mocking sex 'other' for ids 640000 to 640100")
-        for row in rows:
-            if 640000 <= int(row["__id"]) <= 640100:
-                row["sex"] = '"other"'
-            yield row
-    else:
-        for row in rows:
-            yield row
-
-
-def _mock_version_28(id, created, data):
-    if 640000 <= id <= 640020:
-        logging.info("Mocking version 3.0 for ids 640000 to 640020: "
-                     "is_assisted_living = no_response , "
-                     "symptoms_abdominal_pain = true , "
-                     "symptoms_lack_of_appetite_or_skipping_meals = false , "
-                     "routine_workplace_is_outside = no "
-                     "precondition_smoking = long_past_smoker "
-                     "medical_staff_member = true"
-                     "routine_uses_public_transportation = false , "
-                     "routine_visits_prayer_house = true , "
-                     "routine_wears_mask = always , "
-                     "routine_wears_gloves = mostly_yes , "
-                     "routine_last_asked = 2020-03-29T18:16:48.720Z"
-                     )
-        data["is_assisted_living"] = "no_response"
-        data["symptoms_abdominal_pain"] = True
-        data["symptoms_lack_of_appetite_or_skipping_meals"] = False
-        data["routine_workplace_is_outside"] = False
-        data["precondition_smoking"] = "long_past_smoker"
-        data["medical_staff_member"] = True
-        data["routine_uses_public_transportation"] = False
-        data["routine_visits_prayer_house"] = True
-        data["routine_wears_mask"] = "always"
-        data["routine_wears_gloves"] = "mostly_yes"
-        data["routine_last_asked"] = "2020-03-29T18:16:48.720Z"
-        data["version"] = "3.0.0"
-    elif 640021 <= id <= 640040:
-        logging.info("Mocking version 3.0 for ids 640021 to 640040: "
-                     "is_assisted_living = true , "
-                     "symptoms_abdominal_pain = false , "
-                     "symptoms_lack_of_appetite_or_skipping_meals = true , "
-                     "routine_workplace_is_outside = yes + full details "
-                     "precondition_smoking = long_past_smokre "
-                     "medical_staff_member = false"
-                     "routine_uses_public_transportation = true , "
-                     "routine_uses_public_transportation_bus = true, "
-                     "routine_visits_prayer_house = false , "
-                     "routine_wears_mask = no_response, "
-                     "routine_wears_gloves = mostly_no"
-                     )
-        data["is_assisted_living"] = True
-        data["symptoms_abdominal_pain"] = False
-        data["symptoms_lack_of_appetite_or_skipping_meals"] = True
-        data["routine_workplace_is_outside"] = True
-        data["routine_workplace_single_location"] = True
-        data["routine_workplace_weekly_hours"] = 3
-        data["routine_workplace_city_town"] = "תל אביב"
-        data["routine_workplace_street"] = "הרצל"
-        data["precondition_smoking"] = "long_past_smokre"
-        data["medical_staff_member"] = False
-        data["routine_uses_public_transportation"] = True
-        data["routine_uses_public_transportation_bus"] = True
-        data["routine_visits_prayer_house"] = False
-        data["routine_wears_mask"] = "no_response"
-        data["routine_wears_gloves"] = "mostly_no"
-        data["version"] = "3.0.0"
-    elif 640041 <= id <= 640060:
-        logging.info("Mocking version 3.0 for ids 640041 to 640060: "
-                     "is_assisted_living = false , "
-                     "routine_workplace_is_outside = yes + minimal details"
-                     "routine_visits_prayer_house = no_response"
-                     )
-        data["is_assisted_living"] = False
-        data["routine_workplace_is_outside"] = True
-        data["routine_workplace_single_location"] = False
-        data["routine_workplace_weekly_hours"] = 55
-        data["routine_visits_prayer_house"] = "no_response"
-        data["version"] = "3.0.0"
-    elif 640061 <= id <= 640080:
-        logging.info("Mocking version 3.0 for ids 640061 to 640080: "
-                     "is_assisted_living = 'true'")
-        data["is_assisted_living"] = "true"
-        data["version"] = "3.0.0"
-    elif 640081 <= id <= 640100:
-        logging.info("Mocking version 3.0 for ids 640081 to 640100: "
-                     "is_assisted_living = 'false'")
-        data["is_assisted_living"] = "false"
-        data["version"] = "3.0.0"
-    return id, created, data
+# def _mock_gender_other(rows):
+#     if rows.res.name == "db_data":
+#         logging.info("Mocking sex 'other' for ids 640000 to 640100")
+#         for row in rows:
+#             if 640000 <= int(row["__id"]) <= 640100:
+#                 row["sex"] = '"other"'
+#             yield row
+#     else:
+#         for row in rows:
+#             yield row
+#
+#
+# def _mock_version_28(id, created, data):
+#     if 640000 <= id <= 640020:
+#         logging.info("Mocking version 3.0 for ids 640000 to 640020: "
+#                      "is_assisted_living = no_response , "
+#                      "symptoms_abdominal_pain = true , "
+#                      "symptoms_lack_of_appetite_or_skipping_meals = false , "
+#                      "routine_workplace_is_outside = no "
+#                      "precondition_smoking = long_past_smoker "
+#                      "medical_staff_member = true"
+#                      "routine_uses_public_transportation = false , "
+#                      "routine_visits_prayer_house = true , "
+#                      "routine_wears_mask = always , "
+#                      "routine_wears_gloves = mostly_yes , "
+#                      "routine_last_asked = 2020-03-29T18:16:48.720Z"
+#                      )
+#         data["is_assisted_living"] = "no_response"
+#         data["symptoms_abdominal_pain"] = True
+#         data["symptoms_lack_of_appetite_or_skipping_meals"] = False
+#         data["routine_workplace_is_outside"] = False
+#         data["precondition_smoking"] = "long_past_smoker"
+#         data["medical_staff_member"] = True
+#         data["routine_uses_public_transportation"] = False
+#         data["routine_visits_prayer_house"] = True
+#         data["routine_wears_mask"] = "always"
+#         data["routine_wears_gloves"] = "mostly_yes"
+#         data["routine_last_asked"] = "2020-03-29T18:16:48.720Z"
+#         data["version"] = "3.0.0"
+#     elif 640021 <= id <= 640040:
+#         logging.info("Mocking version 3.0 for ids 640021 to 640040: "
+#                      "is_assisted_living = true , "
+#                      "symptoms_abdominal_pain = false , "
+#                      "symptoms_lack_of_appetite_or_skipping_meals = true , "
+#                      "routine_workplace_is_outside = yes + full details "
+#                      "precondition_smoking = long_past_smokre "
+#                      "medical_staff_member = false"
+#                      "routine_uses_public_transportation = true , "
+#                      "routine_uses_public_transportation_bus = true, "
+#                      "routine_visits_prayer_house = false , "
+#                      "routine_wears_mask = no_response, "
+#                      "routine_wears_gloves = mostly_no"
+#                      )
+#         data["is_assisted_living"] = True
+#         data["symptoms_abdominal_pain"] = False
+#         data["symptoms_lack_of_appetite_or_skipping_meals"] = True
+#         data["routine_workplace_is_outside"] = True
+#         data["routine_workplace_single_location"] = True
+#         data["routine_workplace_weekly_hours"] = 3
+#         data["routine_workplace_city_town"] = "תל אביב"
+#         data["routine_workplace_street"] = "הרצל"
+#         data["precondition_smoking"] = "long_past_smokre"
+#         data["medical_staff_member"] = False
+#         data["routine_uses_public_transportation"] = True
+#         data["routine_uses_public_transportation_bus"] = True
+#         data["routine_visits_prayer_house"] = False
+#         data["routine_wears_mask"] = "no_response"
+#         data["routine_wears_gloves"] = "mostly_no"
+#         data["version"] = "3.0.0"
+#     elif 640041 <= id <= 640060:
+#         logging.info("Mocking version 3.0 for ids 640041 to 640060: "
+#                      "is_assisted_living = false , "
+#                      "routine_workplace_is_outside = yes + minimal details"
+#                      "routine_visits_prayer_house = no_response"
+#                      )
+#         data["is_assisted_living"] = False
+#         data["routine_workplace_is_outside"] = True
+#         data["routine_workplace_single_location"] = False
+#         data["routine_workplace_weekly_hours"] = 55
+#         data["routine_visits_prayer_house"] = "no_response"
+#         data["version"] = "3.0.0"
+#     elif 640061 <= id <= 640080:
+#         logging.info("Mocking version 3.0 for ids 640061 to 640080: "
+#                      "is_assisted_living = 'true'")
+#         data["is_assisted_living"] = "true"
+#         data["version"] = "3.0.0"
+#     elif 640081 <= id <= 640100:
+#         logging.info("Mocking version 3.0 for ids 640081 to 640100: "
+#                      "is_assisted_living = 'false'")
+#         data["is_assisted_living"] = "false"
+#         data["version"] = "3.0.0"
+#     return id, created, data
 
 
 def main():
@@ -131,9 +131,9 @@ def main():
             }),
             load_from_db.flow({
                 "where": "(id > 500 and id < 1000) or (id > 180000 and id < 185000) or (id > 600000 and id < 601000) or (id > 640000 and id < 641000) or (id > 670000)",
-                "filter_db_row_callback": _mock_version_28
+                # "filter_db_row_callback": _mock_version_28
             }),
-            _mock_gender_other,
+            # _mock_gender_other,
             add_gps_coordinates.flow({
                 "source_fields": utils.get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["source_fields"],
                 "workplace_source_fields": utils.get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["workplace_source_fields"],

--- a/corona_data_collector/tests/test_gender_other.py
+++ b/corona_data_collector/tests/test_gender_other.py
@@ -1,56 +1,44 @@
-import random
 import logging
-from corona_data_collector import load_from_db, add_gps_coordinates, export_corona_bot_answers
-from avid_covider_pipelines.utils import get_parameters_from_pipeline_spec
-from dataflows import printer, Flow, load
-from .common import test_corona_bot_answers
+from corona_data_collector.tests.common import get_db_test_row, run_full_db_data_test
 
 
 logging.basicConfig(level=logging.INFO)
 
 
-def _mock_gender_other(rows):
-    for row in rows:
-        if row["__id"] in [460001, 460002]:
-            logging.info("Mocking sex for id %s (%s -> %s)" % (row["__id"], row["sex"], '"other"'))
-            row["sex"] = '"other"'
-        yield row
+# get_db_test_row("3.0.0", "sex", "male")  # 734797
+# get_db_test_row("3.0.0", "sex", "female")  # 734800
+# get_db_test_row("3.0.0", "sex", "other")  # 734839
 
 
-Flow(
-    load_from_db.flow({
-        "where": "id > 460000",
-        "limit_rows": 5
-    }),
-    _mock_gender_other,
-    add_gps_coordinates.flow({
-        "source_fields": get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["source_fields"],
-        "get-coords-callback": lambda street, city: (random.uniform(29, 34), random.uniform(34, 36), int(street != city))
-    }),
-    export_corona_bot_answers.flow({
-        "destination_output": "data/corona_data_collector/destination_output"
-    }),
-    printer(fields=[
-        "__id", "__created", "main_age", "sex"
-    ])
-).process()
-Flow(
-    load("data/corona_data_collector/destination_output/corona_bot_answers_10_4_2020_with_coords.csv"),
-    test_corona_bot_answers(
-        lambda row: (str(row["gender"]),),
-        {
-            "460001": ["corona_bot_answers_10_4_2020_with_coords", "2"],
-            "460002": ["corona_bot_answers_10_4_2020_with_coords", "2"],
-            "460003": ["corona_bot_answers_10_4_2020_with_coords", "1"],
-            "460004": ["corona_bot_answers_10_4_2020_with_coords", "0"],
-            "460005": ["corona_bot_answers_10_4_2020_with_coords", "1"],
-            "460006": ["corona_bot_answers_10_4_2020_with_coords", "1"],
-        }
-    ),
-    printer(fields=[
-        "age", "timestamp", "id", "gender"
-    ])
-).process()
+TEST_FIELDS = {
+    # db field            corona_bot_answers field
+    "version":            "questionare_version",
+    "sex":                "gender"
+}
+TEST_DATA = {
+    # id in DB:
+    #   "db field": ("value in db", "value_in_corona_bot_answers")
+    94: {
+        "version": ("0.1.0",),
+        "sex": ("female", "1")
+    },
+    400000: {
+        "version": ("2.2.2",),
+        "sex": ("male", "0")
+    },
+    734797: {
+        "version": ("3.0.0",),
+        "sex": ("male", "0")
+    },
+    734800: {
+        "version": ("3.0.0",),
+        "sex": ("female", "1")
+    },
+    734839: {
+        "version": ("3.0.0",),
+        "sex": ("other", "2")
+    },
+}
 
 
-logging.info("Great Success!")
+run_full_db_data_test(TEST_FIELDS, TEST_DATA)

--- a/corona_data_collector/tests/test_habits_routine_fields.py
+++ b/corona_data_collector/tests/test_habits_routine_fields.py
@@ -58,7 +58,7 @@ TEST_DATA = {
         "routine_visits_prayer_house":              (False, "0"),
         "routine_wears_mask":                       ("always", "3"),
         "routine_wears_gloves":                     ("never", "0"),
-        "routine_last_asked":                       (1588837240349, "2020-05-07T10:40:40.000Z"),
+        "routine_last_asked":                       (1588837240349, "2020-05-07T07:40:40.000Z"),
     },
     # get_db_test_row("3.0.0", "routine_uses_public_transportation", "true", show_fields=[
     #     "routine_uses_public_transportation",  "routine_uses_public_transportation_bus", "routine_uses_public_transportation_train", "routine_uses_public_transportation_taxi", "routine_uses_public_transportation_other"
@@ -73,7 +73,7 @@ TEST_DATA = {
         "routine_visits_prayer_house":              (False, "0"),
         "routine_wears_mask":                       ("always", "3"),
         "routine_wears_gloves":                     ("never", "0"),
-        "routine_last_asked":                       (1588795349500, "2020-05-06T23:02:29.000Z"),
+        "routine_last_asked":                       (1588795349500, "2020-05-06T20:02:29.000Z"),
     },
      # 732802 (taxi=true, train=null, bus=true, other=null)
     732802: {
@@ -86,7 +86,7 @@ TEST_DATA = {
         "routine_visits_prayer_house":              (False, "0"),
         "routine_wears_mask":                       ("mostly_yes", "2"),
         "routine_wears_gloves":                     ("mostly_no", "1"),
-        "routine_last_asked":                       (1588795887517, "2020-05-06T23:11:27.000Z"),
+        "routine_last_asked":                       (1588795887517, "2020-05-06T20:11:27.000Z"),
     },
 }
 

--- a/corona_data_collector/tests/test_habits_routine_fields.py
+++ b/corona_data_collector/tests/test_habits_routine_fields.py
@@ -1,102 +1,94 @@
-import random
 import logging
-from corona_data_collector import load_from_db, add_gps_coordinates, export_corona_bot_answers
-from avid_covider_pipelines.utils import get_parameters_from_pipeline_spec
-from dataflows import printer, Flow, load
-from .common import test_corona_bot_answers
+from corona_data_collector.tests.common import get_db_test_row, run_full_db_data_test
 
 
 logging.basicConfig(level=logging.INFO)
 
 
-def _mock_habits_fields(id, created, data):
-    if id == 600304:
-        logging.info("Mocking version 3.0 for id 600304 with "
-                     "routine_uses_public_transportation = false , "
-                     "routine_visits_prayer_house = true , "
-                     "routine_wears_mask = always , "
-                     "routine_wears_gloves = mostly_yes , "
-                     "routine_last_asked = 2020-03-29T18:16:48.720Z")
-        data["routine_uses_public_transportation"] = False
-        data["routine_visits_prayer_house"] = True
-        data["routine_wears_mask"] = "always"
-        data["routine_wears_gloves"] = "mostly_yes"
-        data["routine_last_asked"] = "2020-03-29T18:16:48.720Z"
-        data["version"] = "3.0.0"
-    elif id == 676580:
-        logging.info("Mocking version 3.0 for id 676580 with "
-                     "routine_uses_public_transportation = true , "
-                     "routine_uses_public_transportation_bus = true, "
-                     "routine_visits_prayer_house = false , "
-                     "routine_wears_mask = no_response, "
-                     "routine_wears_gloves = mostly_no")
-        data["routine_uses_public_transportation"] = True
-        data["routine_uses_public_transportation_bus"] = True
-        data["routine_visits_prayer_house"] = False
-        data["routine_wears_mask"] = "no_response"
-        data["routine_wears_gloves"] = "mostly_no"
-        data["version"] = "3.0.0"
-    elif id == 676581:
-        logging.info("Mocking version 3.0 for id 676581 with "
-                     "routine_visits_prayer_house = no_response")
-        data["routine_visits_prayer_house"] = "no_response"
-        data["version"] = "3.0.0"
-    elif id == 701508:
-        logging.info("Mocking version 3.0 for id 701508 "
-                     "without values")
-        data["version"] = "3.0.0"
-    return id, created, data
+TEST_FIELDS = {
+    # db field                                           corona_bot_answers field
+    "version":                                           "questionare_version",
+    "routine_uses_public_transportation":                "public_transportation_last_week",
+    "routine_uses_public_transportation_bus":            "public_transportation_bus",
+    "routine_uses_public_transportation_train":          "public_transportation_train",
+    "routine_uses_public_transportation_taxi":           "public_transportation_taxi",
+    "routine_uses_public_transportation_other":          "public_transportation_other",
+    "routine_visits_prayer_house":                       "habits_prayer_house",
+    "routine_wears_mask":                                "last_week_wear_mask",
+    "routine_wears_gloves":                              "last_week_wear_gloves",
+    "routine_last_asked":                                "routine_last_asked",
+}
+TEST_DATA = {
+    # id in DB:
+    #   "db field": ("value in db", "value_in_corona_bot_answers")
+    94: {
+        "version": ("0.1.0",),
+        "routine_uses_public_transportation":       (None, ""),
+        "routine_uses_public_transportation_bus":   (None, ""),
+        "routine_uses_public_transportation_train": (None, ""),
+        "routine_uses_public_transportation_taxi":  (None, ""),
+        "routine_uses_public_transportation_other": (None, ""),
+        "routine_visits_prayer_house":              (None, ""),
+        "routine_wears_mask":                       (None, ""),
+        "routine_wears_gloves":                     (None, ""),
+        "routine_last_asked":                       (None, ""),
+    },
+    400000: {
+        "version": ("2.2.2",),
+        "routine_uses_public_transportation":       (None, ""),
+        "routine_uses_public_transportation_bus":   (None, ""),
+        "routine_uses_public_transportation_train": (None, ""),
+        "routine_uses_public_transportation_taxi":  (None, ""),
+        "routine_uses_public_transportation_other": (None, ""),
+        "routine_visits_prayer_house":              (None, ""),
+        "routine_wears_mask":                       (None, ""),
+        "routine_wears_gloves":                     (None, ""),
+        "routine_last_asked":                       (None, ""),
+    },
+    # get_db_test_row("3.0.0", "routine_uses_public_transportation", "false", show_fields=[
+    #     "routine_uses_public_transportation",  "routine_uses_public_transportation_bus", "routine_uses_public_transportation_train", "routine_uses_public_transportation_taxi", "routine_uses_public_transportation_other"
+    # ])  # 734885
+    734885: {
+        "version": ("3.0.0",),
+        "routine_uses_public_transportation":       (False, "0"),
+        "routine_uses_public_transportation_bus":   (None,  "0"),
+        "routine_uses_public_transportation_train": (None,  "0"),
+        "routine_uses_public_transportation_taxi":  (None,  "0"),
+        "routine_uses_public_transportation_other": (None,  "0"),
+        "routine_visits_prayer_house":              (False, "0"),
+        "routine_wears_mask":                       ("always", "3"),
+        "routine_wears_gloves":                     ("never", "0"),
+        "routine_last_asked":                       (1588837240349, "2020-05-07T10:40:40.000Z"),
+    },
+    # get_db_test_row("3.0.0", "routine_uses_public_transportation", "true", show_fields=[
+    #     "routine_uses_public_transportation",  "routine_uses_public_transportation_bus", "routine_uses_public_transportation_train", "routine_uses_public_transportation_taxi", "routine_uses_public_transportation_other"
+    # ])  # 732749 (taxi=null, train=null, bus=true, other=null)
+    732749: {
+        "version": ("3.0.0",),
+        "routine_uses_public_transportation":       (True, "1"),
+        "routine_uses_public_transportation_bus":   (True, "1"),
+        "routine_uses_public_transportation_train": (None, "0"),
+        "routine_uses_public_transportation_taxi":  (None, "0"),
+        "routine_uses_public_transportation_other": (None, "0"),
+        "routine_visits_prayer_house":              (False, "0"),
+        "routine_wears_mask":                       ("always", "3"),
+        "routine_wears_gloves":                     ("never", "0"),
+        "routine_last_asked":                       (1588795349500, "2020-05-06T23:02:29.000Z"),
+    },
+     # 732802 (taxi=true, train=null, bus=true, other=null)
+    732802: {
+        "version": ("3.0.0",),
+        "routine_uses_public_transportation":       (True, "1"),
+        "routine_uses_public_transportation_bus":   (True, "1"),
+        "routine_uses_public_transportation_train": (None, "0"),
+        "routine_uses_public_transportation_taxi":  (True, "1"),
+        "routine_uses_public_transportation_other": (None, "0"),
+        "routine_visits_prayer_house":              (False, "0"),
+        "routine_wears_mask":                       ("mostly_yes", "2"),
+        "routine_wears_gloves":                     ("mostly_no", "1"),
+        "routine_last_asked":                       (1588795887517, "2020-05-06T23:11:27.000Z"),
+    },
+}
 
 
-Flow(
-    load_from_db.flow({
-        "where": "id in (94, 180075, 600304, 600895, 676580, 676581, 701508)",
-        "filter_db_row_callback": _mock_habits_fields
-    }),
-    add_gps_coordinates.flow({
-        "source_fields": get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["source_fields"],
-        "get-coords-callback": lambda street, city: (random.uniform(29, 34), random.uniform(34, 36), int(street != city))
-    }),
-    export_corona_bot_answers.flow({
-        "destination_output": "data/corona_data_collector/destination_output"
-    }),
-    printer(fields=[
-        "__id", "__created", "version",
-        "routine_uses_public_transportation", "routine_uses_public_transportation_bus", "routine_uses_public_transportation_train", "routine_uses_public_transportation_taxi", "routine_uses_public_transportation_other",
-        "routine_visits_prayer_house", "routine_wears_mask", "routine_wears_gloves",
-        "routine_last_asked"
-    ]),
-).process()
-Flow(
-    load("data/corona_data_collector/destination_output/corona_bot_answers_22_3_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_25_3_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_20_4_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_29_4_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_2_5_2020_with_coords.csv"),
-    test_corona_bot_answers(
-        lambda row: [str(row[k]) for k in [
-            "questionare_version", "public_transportation_last_week", "public_transportation_bus", "public_transportation_train", "public_transportation_taxi", "public_transportation_other",
-            "habits_prayer_house", "last_week_wear_mask", "last_week_wear_gloves",
-            "routine_last_asked"
-        ]],
-        {
-            #                                                               last weeek      bus      train      taxi      other     prayer_house    wear_mask     wear_gloves    last_asked
-            "94": ["corona_bot_answers_22_3_2020_with_coords",     "0.1.0", "",             "",      "",        "",       "",       "",            "",            "",            ""],
-            "180075": ["corona_bot_answers_25_3_2020_with_coords", "1.0.1", "",             "",      "",        "",       "",       "",            "",            "",            ""],
-            "600304": ["corona_bot_answers_20_4_2020_with_coords", "3.0.0", "0",            "0",     "0",       "0",      "0",      "1",           "3",           "2",           "2020-03-29T18:16:48.720Z"],
-            "600895": ["corona_bot_answers_20_4_2020_with_coords", "2.6.0", "",             "",      "",        "",       "",       "",            "",            "",            ""],
-            "676580": ["corona_bot_answers_29_4_2020_with_coords", "3.0.0", "1",            "1",     "0",       "0",      "0",      "0",           "4",           "1",           ""],
-            "676581": ["corona_bot_answers_29_4_2020_with_coords", "3.0.0", "0",            "0",     "0",       "0",      "0",      "2",           "4",           "4",           ""],
-            "701508": ["corona_bot_answers_2_5_2020_with_coords",  "3.0.0", "0",            "0",     "0",       "0",      "0",      "2",           "4",           "4",           ""],
-        }
-    ),
-    printer(fields=[
-        "timestamp", "id", "questionare_version",
-        "public_transportation_last_week", "public_transportation_bus", "public_transportation_train", "public_transportation_taxi", "public_transportation_other",
-        "habits_prayer_house", "last_week_wear_mask", "last_week_wear_gloves",
-        "routine_last_asked"
-    ])
-).process()
-
-
-logging.info("Great Success!")
+run_full_db_data_test(TEST_FIELDS, TEST_DATA)

--- a/corona_data_collector/tests/test_v3_0_symptoms.py
+++ b/corona_data_collector/tests/test_v3_0_symptoms.py
@@ -1,66 +1,35 @@
-import random
 import logging
-from corona_data_collector import load_from_db, add_gps_coordinates, export_corona_bot_answers
-from avid_covider_pipelines.utils import get_parameters_from_pipeline_spec
-from dataflows import printer, Flow, load
-from .common import test_corona_bot_answers
+from corona_data_collector.tests.common import get_db_test_row, run_full_db_data_test
 
 
 logging.basicConfig(level=logging.INFO)
 
 
-def _mock_abdominal_pain(id, created, data):
-    if id == 600304:
-        logging.info("Mocking version 3.0 for id 600304 with symptoms_abdominal_pain = true , symptoms_lack_of_appetite_or_skipping_meals = false")
-        data["symptoms_abdominal_pain"] = True
-        data["symptoms_lack_of_appetite_or_skipping_meals"] = False
-        data["version"] = "3.0.0"
-    elif id == 676580:
-        logging.info("Mocking version 3.0 for id 676580 with symptoms_abdominal_pain = false , symptoms_lack_of_appetite_or_skipping_meals = true")
-        data["symptoms_abdominal_pain"] = False
-        data["symptoms_lack_of_appetite_or_skipping_meals"] = True
-        data["version"] = "3.0.0"
-    return id, created, data
+TEST_FIELDS = {
+    # db field                                           corona_bot_answers field
+    "version":                                           "questionare_version",
+    "symptoms_abdominal_pain":                           "symptoms_abdominal_pain",
+    "symptoms_lack_of_appetite_or_skipping_meals":       "symptoms_lack_of_appetite_skipping_meals",
+}
+TEST_DATA = {
+    # id in DB:
+    #   "db field": ("value in db", "value_in_corona_bot_answers")
+    94: {
+        "version": ("0.1.0",),
+        "symptoms_abdominal_pain":                         (None, ""),
+        "symptoms_lack_of_appetite_or_skipping_meals":     (None, ""),
+    },
+    734863: {
+        "version": ("3.0.0",),
+        "symptoms_abdominal_pain":                         (True, "1"),
+        "symptoms_lack_of_appetite_or_skipping_meals":     (True, "1"),
+    },
+    734839: {
+        "version": ("3.0.0",),
+        "symptoms_abdominal_pain":                         (None, "0"),
+        "symptoms_lack_of_appetite_or_skipping_meals":     (True, "1"),
+    },
+}
 
 
-Flow(
-    load_from_db.flow({
-        "where": "id in (94, 180075, 600304, 600895, 676580, 676581, 701508)",
-        "filter_db_row_callback": _mock_abdominal_pain
-    }),
-    add_gps_coordinates.flow({
-        "source_fields": get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["source_fields"],
-        "get-coords-callback": lambda street, city: (random.uniform(29, 34), random.uniform(34, 36), int(street != city))
-    }),
-    export_corona_bot_answers.flow({
-        "destination_output": "data/corona_data_collector/destination_output"
-    }),
-    printer(fields=[
-        "__id", "__created", "version", "symptoms_abdominal_pain", "symptoms_lack_of_appetite_or_skipping_meals"
-    ]),
-).process()
-Flow(
-    load("data/corona_data_collector/destination_output/corona_bot_answers_22_3_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_25_3_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_20_4_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_29_4_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_2_5_2020_with_coords.csv"),
-    test_corona_bot_answers(
-        lambda row: (str(row["symptoms_abdominal_pain"]), str(row["symptoms_lack_of_appetite_skipping_meals"]), str(row["questionare_version"])),
-        {
-            "94": ["corona_bot_answers_22_3_2020_with_coords", "", "", "0.1.0"],
-            "180075": ["corona_bot_answers_25_3_2020_with_coords", "", "", "1.0.1"],
-            "600304": ["corona_bot_answers_20_4_2020_with_coords", "1", "0", "3.0.0"],
-            "600895": ["corona_bot_answers_20_4_2020_with_coords", "", "", "2.6.0"],
-            "676580": ["corona_bot_answers_29_4_2020_with_coords", "0", "1", "3.0.0"],
-            "676581": ["corona_bot_answers_29_4_2020_with_coords", "", "", "2.7.4"],
-            "701508": ["corona_bot_answers_2_5_2020_with_coords", "", "", "2.7.6"],
-        }
-    ),
-    printer(fields=[
-        "timestamp", "id", "symptoms_abdominal_pain", "symptoms_lack_of_appetite_skipping_meals", "questionare_version"
-    ])
-).process()
-
-
-logging.info("Great Success!")
+run_full_db_data_test(TEST_FIELDS, TEST_DATA)

--- a/corona_data_collector/tests/test_work_outside_questions.py
+++ b/corona_data_collector/tests/test_work_outside_questions.py
@@ -1,100 +1,59 @@
-import random
 import logging
-from corona_data_collector import load_from_db, add_gps_coordinates, export_corona_bot_answers
-from avid_covider_pipelines.utils import get_parameters_from_pipeline_spec
-from dataflows import printer, Flow, load
-from .common import test_corona_bot_answers
+from corona_data_collector.tests.common import get_db_test_row, run_full_db_data_test
 
 
 logging.basicConfig(level=logging.INFO)
 
 
-def _mock_work_outside(id, created, data):
-    if id == 600304:
-        logging.info("Mocking version 3.0 for id 600304 with routine_workplace_is_outside = no")
-        data["routine_workplace_is_outside"] = False
-        data["version"] = "3.0.0"
-    elif id == 676580:
-        logging.info("Mocking version 3.0 for id 676580 with routine_workplace_is_outside = yes + full details")
-        data["routine_workplace_is_outside"] = True
-        data["routine_workplace_single_location"] = True
-        data["routine_workplace_weekly_hours"] = 3
-        data["routine_workplace_city_town"] = "תל אביב"
-        data["routine_workplace_street"] = "הרצל"
-        data["version"] = "3.0.0"
-    elif id == 676581:
-        logging.info("Mocking version 3.0 for id 676581 with routine_workplace_is_outside = yes + minimal details")
-        data["routine_workplace_is_outside"] = True
-        data["routine_workplace_single_location"] = False
-        data["routine_workplace_weekly_hours"] = 55
-        data["version"] = "3.0.0"
-    elif id == 180075:
-        logging.info("Mocking version 3.0 for id 180075 with routine_workplace_is_outside = yes + invalid details")
-        data["routine_workplace_is_outside"] = True
-        data["routine_workplace_weekly_hours"] = "foobar"
-        data["routine_workplace_city_town"] = 55
-        data["routine_workplace_street"] = 44
-        data["version"] = "3.0.0"
-    return id, created, data
+TEST_FIELDS = {
+    # db field                                           corona_bot_answers field
+    "version":                                           "questionare_version",
+    "routine_workplace_is_outside":                      "work_outside",
+    "routine_workplace_weekly_hours":                    "work_outside_avg_weekly_hours",
+    "routine_workplace_city_town":                       "workplace_city_town",
+    "routine_workplace_street":                          "workplace_street",
+    "routine_workplace_single_location":                 "workplace_single_location",
+    "workplace_lat":                                     "workplace_lat",
+    "workplace_lng":                                     "workplace_lng",
+    "workplace_street_accurate":                         "workplace_single_location",
+}
+TEST_DATA = {
+    # id in DB:
+    #   "db field": ("value in db", "value_in_corona_bot_answers")
+    94: {
+        "version": ("0.1.0",),
+        "routine_workplace_is_outside":       (None, ""),
+        "routine_workplace_weekly_hours":     (None, ""),
+        "routine_workplace_city_town":        (None, ""),
+        "routine_workplace_street":           (None, ""),
+        "routine_workplace_single_location":  (None, ""),
+        "workplace_lat":                      (None, "0"),
+        "workplace_lng":                      (None, "0"),
+        "workplace_street_accurate":          (None, ""),
+    },
+    734863: {
+        "version": ("3.0.0",),
+        "routine_workplace_is_outside":       (False, "0"),
+        "routine_workplace_weekly_hours":     (None, "0"),
+        "routine_workplace_city_town":        (None, ""),
+        "routine_workplace_street":           (None, ""),
+        "routine_workplace_single_location":  (None, "0"),
+        "workplace_lat":                      (None, "0"),
+        "workplace_lng":                      (None, "0"),
+        "workplace_street_accurate":          (None, "0"),
+    },
+    734839: {
+        "version": ("3.0.0",),
+        "routine_workplace_is_outside":       (True, "1"),
+        "routine_workplace_weekly_hours":     ("5", "5"),
+        "routine_workplace_city_town":        ("מזכרת בתיה", "מזכרת בתיה"),
+        "routine_workplace_street":           ( "הגפן", "הגפן"),
+        "routine_workplace_single_location":  (True, "1"),
+        "workplace_lat":                      (None, "31.8561771"),
+        "workplace_lng":                      (None, "34.8366475"),
+        "workplace_street_accurate":          (None, "1"),
+    },
+}
 
 
-Flow(
-    load_from_db.flow({
-        "where": "id in (94, 180075, 600304, 600895, 676580, 676581, 701508)",
-        "filter_db_row_callback": _mock_work_outside
-    }),
-    add_gps_coordinates.flow({
-        "source_fields": get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["source_fields"],
-        "workplace_source_fields": get_parameters_from_pipeline_spec("pipeline-spec.yaml", "corona_data_collector", "corona_data_collector.add_gps_coordinates")["workplace_source_fields"],
-        "get-coords-callback": lambda street, city: (random.uniform(29, 34), random.uniform(34, 36), int(street != city))
-    }),
-    export_corona_bot_answers.flow({
-        "destination_output": "data/corona_data_collector/destination_output"
-    }),
-    printer(fields=[
-        "__id", "__created", "version", "routine_workplace_is_outside", "routine_workplace_weekly_hours", "routine_workplace_city_town",
-        "routine_workplace_street", "workplace_lat", "workplace_lng", "workplace_street_accurate", "routine_workplace_single_location"
-    ]),
-).process()
-
-def _test_workplace_lat_lng(row):
-    if row["id"] in ["180075", "676580"]:
-        assert row["workplace_lat"] and row["workplace_lng"], (row["id"], row["workplace_lat"], row["workplace_lng"])
-    else:
-        assert row["workplace_lat"] == "0" and row["workplace_lng"] == "0", (row["id"], row["workplace_lat"], row["workplace_lng"])
-
-
-Flow(
-    load("data/corona_data_collector/destination_output/corona_bot_answers_22_3_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_25_3_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_20_4_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_29_4_2020_with_coords.csv"),
-    load("data/corona_data_collector/destination_output/corona_bot_answers_2_5_2020_with_coords.csv"),
-    test_corona_bot_answers(
-        lambda row: (
-            str(row["questionare_version"]), str(row["work_outside"]), str(row["work_outside_avg_weekly_hours"]),
-            str(row["workplace_city_town"]), str(row["workplace_street"]),
-            str(row["workplace_street_accurate"]),
-            str(row["workplace_single_location"])
-        ),
-        {
-                                                                       #  work_outside    hours    city_town    street    accurate    single_location
-            "94": ["corona_bot_answers_22_3_2020_with_coords", "0.1.0",       "",         "",      "",          "",       "0",        ""],
-            "180075": ["corona_bot_answers_25_3_2020_with_coords", "3.0.0",   "1",        "0",     "55",        "44",     "1",        "0"],
-            "600304": ["corona_bot_answers_20_4_2020_with_coords", "3.0.0",   "0",        "0",     "",          "",       "0",        "0"],
-            "600895": ["corona_bot_answers_20_4_2020_with_coords", "2.6.0",   "",         "",      "",          "",       "0",        ""],
-            "676580": ["corona_bot_answers_29_4_2020_with_coords", "3.0.0",   "1",        "3",     "תל אביב",   "הרצל",   "1",        "1"],
-            "676581": ["corona_bot_answers_29_4_2020_with_coords", "3.0.0",   "1",        "55",    "",          "",       "0",        "0"],
-            "701508": ["corona_bot_answers_2_5_2020_with_coords", "2.7.6",    "",          "",     "",          "",       "0",        ""],
-        },
-        _test_workplace_lat_lng
-    ),
-    printer(fields=[
-        "timestamp", "id", "questionare_version", "work_outside", "work_outside_avg_weekly_hours",
-        "workplace_city_town", "workplace_street", "workplace_lat", "workplace_lng", "workplace_street_accurate",
-        "workplace_single_location"
-    ])
-).process()
-
-
-logging.info("Great Success!")
+run_full_db_data_test(TEST_FIELDS, TEST_DATA, get_real_coords=True)


### PR DESCRIPTION
* Fixed format of datetime field `routine_last_update`
* Changed tests to use real data (instead of mock data)
* Improved test code to make it clearer regarding the values and field names

See the relevant tests for the definitive mapping between DB field names and values to corona_bot_answers fields and values:

* [assisted living](https://github.com/hasadna/avid-covider-pipelines/blob/fixes-and-tests-for-v3.0.0-after-release/corona_data_collector/tests/test_asisted_living.py)
* [gender other](https://github.com/hasadna/avid-covider-pipelines/blob/fixes-and-tests-for-v3.0.0-after-release/corona_data_collector/tests/test_gender_other.py)
* [habits and routine fields](https://github.com/hasadna/avid-covider-pipelines/blob/fixes-and-tests-for-v3.0.0-after-release/corona_data_collector/tests/test_habits_routine_fields.py)
* [smoking and medical staff member](https://github.com/hasadna/avid-covider-pipelines/blob/fixes-and-tests-for-v3.0.0-after-release/corona_data_collector/tests/test_smoking_medical_staff_member.py)
* [v3.0.0 symptoms](https://github.com/hasadna/avid-covider-pipelines/blob/fixes-and-tests-for-v3.0.0-after-release/corona_data_collector/tests/test_v3_0_symptoms.py)
* [workplace questions](https://github.com/hasadna/avid-covider-pipelines/blob/fixes-and-tests-for-v3.0.0-after-release/corona_data_collector/tests/test_work_outside_questions.py)
