### PR TITLE
update covid19-israel source spec maps_generate_daily_summary: add all_dates to external sharing

### DIFF
--- a/covid19israel.source-spec.yaml
+++ b/covid19israel.source-spec.yaml
@@ -126,6 +126,7 @@ maps_generate_daily_summary:
           deploy_key: hasadna_avid_covider_raw_data
           files:
             daily_summary: "input/{POSTERIOR_DATE}.csv"
+            all_dates: "input/all_dates.csv"
   skip-failures: true
 
 


### PR DESCRIPTION
adds `input/all_dates.csv` as part of external sharing to hasadna/avid-covider-raw-data