### PR TITLE
remove maccabi data from the centralized geo-coder

### DIFF
--- a/corona_data_collector/add_gps_coordinates.py
+++ b/corona_data_collector/add_gps_coordinates.py
@@ -185,9 +185,6 @@ if __name__ == "__main__":
                 "עיר / ישוב מגורים": "city",
                 "עיר / יישוב מגורים": "city",
                 "רחוב מגורים": "street",
-            },
-            "maccabi": {
-                "yishuv": "city",
             }
         },
         'dump_to_path': 'data/corona_data_collector/add_gps_coordinates',

--- a/corona_data_collector/download_gdrive_data.py
+++ b/corona_data_collector/download_gdrive_data.py
@@ -121,7 +121,6 @@ if __name__ == "__main__":
         "file_sources": {
             "COVID-19-English.csv": "google",
             "COVID-19-Russian.csv": "google",
-            "COVID-19-Hebrew.csv": "hebrew_google",
-            "maccabi-2020-04-22.csv": "maccabi",
+            "COVID-19-Hebrew.csv": "hebrew_google"
         }
     }).process()

--- a/corona_data_collector/tests/test_flow.py
+++ b/corona_data_collector/tests/test_flow.py
@@ -126,7 +126,6 @@ def main():
                     "COVID-19-English.csv": "google",
                     "COVID-19-Russian.csv": "google",
                     "COVID-19-Hebrew.csv": "hebrew_google",
-                    "maccabi_updated.csv": "maccabi",
                 }
             }),
             load_from_db.flow({

--- a/pipeline-spec.yaml
+++ b/pipeline-spec.yaml
@@ -41,7 +41,6 @@ corona_data_collector:
           COVID-19-English.csv: google
           COVID-19-Russian.csv: google
           COVID-19-Hebrew.csv: hebrew_google
-          maccabi_updated.csv: maccabi
     - flow: corona_data_collector.load_from_db
 #      parameters:
 #        limit_rows: 200
@@ -63,9 +62,6 @@ corona_data_collector:
             "עיר / ישוב מגורים": "city",
             "עיר / יישוב מגורים": "city",
             "רחוב מגורים": "street",
-          },
-          "maccabi": {
-            "yishuv": "city",
           }
         }
         workplace_source_fields: {


### PR DESCRIPTION
waiting for merge of PR in covid19-israel repo first

maccabi data is geo-coded using a different method in covid19-israel repository