### PR TITLE
multiple changes related to covid19israel external sharing packages and github sha1

### DIFF
--- a/avid_covider_pipelines/run_covid19_israel.py
+++ b/avid_covider_pipelines/run_covid19_israel.py
@@ -57,7 +57,8 @@ def run_covid19_israel(parameters, run_row):
         if utils.subprocess_call_log(
                 cmd,
                 log_file=log_filename,
-                cwd='../COVID19-ISRAEL'
+                cwd='../COVID19-ISRAEL',
+                env={**os.environ, "COVID19_ISRAEL_GITHUB_SHA1": globals().get('COVID19_ISRAEL_GITHUB_SHA1', '_')}
         ) != 0:
             run_row['error'] = 'yes'
             logging.error('Failed to run COVID19-ISRAEL module %s with args %s' % (parameters['module'], args))

--- a/covid19israel.source-spec.yaml
+++ b/covid19israel.source-spec.yaml
@@ -116,6 +116,9 @@ maps_generate_daily_summary:
           files:
             daily_summary: "input/{POSTERIOR_DATE}.csv"
             all_dates: "input/all_dates.csv"
+            latest_ts: "input/ts.txt"
+          file_contents:
+            "input/commit_id.txt": "{COVID19_ISRAEL_GITHUB_SHA1}"
   skip-failures: true
 
 

--- a/covid19israel.source-spec.yaml
+++ b/covid19israel.source-spec.yaml
@@ -34,8 +34,10 @@
 #
 # external_sharing_packages:
 #
-#   list of output packages to share to external sources (only if the step completes successfully)
-#   each item in the list has the following attributes:
+#   list of output packages to share to external sources (only if the step completes successfully).
+#   some fields can contain python format values from package metadata, this includes all fields in the external sharing package json
+#   as well as the following fields: COVID19_ISRAEL_GITHUB_SHA1
+#   each item in the external_sharing_packages list can have the following attributes:
 #     package_path: path to json file in COVID19-ISRAEL repository which was generated using external_sharing.save_package
 #     publish_targets: list of targets to publish the package to, each item has the following attributes:
 #        github_repo: repository to publish the data to

--- a/covid19israel.source-spec.yaml
+++ b/covid19israel.source-spec.yaml
@@ -44,13 +44,16 @@
 #        deploy_key: id of deploy key with write access to the repository
 #        files: list of files:
 #           key: key from the external sharing package
-#           value: target path in the repository to save the file int.
+#           value: target path in the repository to save the file into.
 #                  the value can contain values from the package metadata in standard python format e.g. {metadata_attribute_name}
 #        files_foreach: allows to get a dynamic list of files form the package:
 #           key: name of value from the package meteadata which is a list of strings
 #           value: object with the following key/values:
 #             key: key from package, may include {foreach_value} replaced by an item from the list as well as other package metadata
 #             value: target path, may include {foreach_value} as well as other package metadata
+#        file_contents: allows to create files with dynamic content based on package metadata
+#           key: target path in the repository to save the file content into
+#           value: the file content, can include package metadata in standard python format e.g. {metadata_attribute_name}
 #
 #
 # skip-failures:

--- a/datapackage_pipelines_covid19israel/publish_external_sharing_packages.py
+++ b/datapackage_pipelines_covid19israel/publish_external_sharing_packages.py
@@ -25,21 +25,28 @@ def flow(parameters, *_):
             }
             package_descriptor["COVID19_ISRAEL_GITHUB_SHA1"] = COVID19_ISRAEL_GITHUB_SHA1
             for publish_target in package["publish_targets"]:
-                assert "github_repo" in publish_target and "deploy_key" in publish_target and ("files" in publish_target or "files_foreach" in publish_target)
+                assert "files" in publish_target or "files_foreach" in publish_target or "file_contents" in publish_target
                 with tempfile.TemporaryDirectory() as tmpdir:
-                    source_deploy_key_file = os.environ["DEPLOY_KEY_FILE_" + publish_target["deploy_key"]]
-                    deploy_key_file = os.path.join(tmpdir, "deploy_key")
-                    shutil.copyfile(source_deploy_key_file, deploy_key_file)
-                    os.chmod(deploy_key_file, 0o400)
-                    gitenv = {
-                        **os.environ,
-                        "GIT_SSH_COMMAND": "ssh -i %s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes" % deploy_key_file
-                    }
+                    deploy_key = publish_target.get("deploy_key")
+                    if deploy_key:
+                        source_deploy_key_file = os.environ["DEPLOY_KEY_FILE_" + publish_target["deploy_key"]]
+                        deploy_key_file = os.path.join(tmpdir, "deploy_key")
+                        shutil.copyfile(source_deploy_key_file, deploy_key_file)
+                        os.chmod(deploy_key_file, 0o400)
+                        gitenv = {
+                            **os.environ,
+                            "GIT_SSH_COMMAND": "ssh -i %s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes" % deploy_key_file
+                        }
                     branch = publish_target.get("branch", "master")
                     repodir = os.path.join(tmpdir, "repo")
-                    assert subprocess_call_log(["git", "clone", "--depth", "1", "--branch", branch, "git@github.com:%s.git" % publish_target["github_repo"], repodir], env=gitenv) == 0
-                    assert subprocess_call_log(["git", "config", "user.name", "avid-covider-pipelines"], cwd=repodir) == 0
-                    assert subprocess_call_log(["git", "config", "user.email", "avid-covider-pipelines@localhost"], cwd=repodir) == 0
+                    github_repo = publish_target.get("github_repo")
+                    if github_repo:
+                        assert deploy_key
+                        assert subprocess_call_log(["git", "clone", "--depth", "1", "--branch", branch, "git@github.com:%s.git" % publish_target["github_repo"], repodir], env=gitenv) == 0
+                        assert subprocess_call_log(["git", "config", "user.name", "avid-covider-pipelines"], cwd=repodir) == 0
+                        assert subprocess_call_log(["git", "config", "user.email", "avid-covider-pipelines@localhost"], cwd=repodir) == 0
+                    else:
+                        os.mkdir(repodir)
                     num_added = 0
                     files = {**publish_target.get("files", {})}
                     for metadata_list_key, files_foreach in publish_target.get("files_foreach", {}).items():
@@ -56,13 +63,37 @@ def flow(parameters, *_):
                             continue
                         source_path = os.path.join("..", "COVID19-ISRAEL", resources[resource_name]["path"])
                         logging.info("%s: %s --> %s" % (resource_name, source_path, target_fullpath))
+                        os.makedirs(os.path.dirname(target_fullpath), exist_ok=True)
                         shutil.copyfile(source_path, target_fullpath)
-                        assert subprocess_call_log(["git", "add", target_path], cwd=repodir) == 0
+                        if github_repo:
+                            assert subprocess_call_log(["git", "add", target_path], cwd=repodir) == 0
+                        num_added += 1
+                    for target_path_template, file_contents_template in publish_target.get("file_contents", {}).items():
+                        target_path = target_path_template.format(**package_descriptor)
+                        target_fullpath = os.path.join(repodir, target_path)
+                        file_contents = file_contents_template.format(**package_descriptor)
+                        if os.path.exists(target_fullpath):
+                            with open(target_fullpath) as f:
+                                if f.read() == file_contents:
+                                    logging.info("File contents is not changed: %s" % target_path)
+                                    continue
+                        logging.info("Writing file contents to target path: %s" % target_fullpath)
+                        os.makedirs(os.path.dirname(target_fullpath), exist_ok=True)
+                        with open(target_fullpath, "w") as f:
+                            f.write(file_contents)
+                        if github_repo:
+                            assert subprocess_call_log(["git", "add", target_path], cwd=repodir) == 0
                         num_added += 1
                     if num_added > 0:
-                        logging.info("Committing %s changes" % num_added)
-                        assert subprocess_call_log(["git", "commit", "-m", "automated update from hasadna/avid-covider-pipelines"], cwd=repodir) == 0
-                        assert subprocess_call_log(["git", "push", "origin", branch], cwd=repodir, env=gitenv) == 0
+                        if github_repo:
+                            logging.info("Committing %s changes" % num_added)
+                            assert subprocess_call_log(["git", "commit", "-m", "automated update from hasadna/avid-covider-pipelines"], cwd=repodir) == 0
+                            assert subprocess_call_log(["git", "push", "origin", branch], cwd=repodir, env=gitenv) == 0
+                        elif publish_target.get("zipfile"):
+                            assert subprocess_call_log(["zip", "-r", "../output.zip", "."], cwd=repodir) == 0
+                            shutil.copyfile(os.path.join(tmpdir, "output.zip"), publish_target["zipfile"])
+                        else:
+                            logging.warning("no publish target")
                     else:
                         logging.info("No changes to commit")
             yield {"name": package_descriptor["name"], "datetime": package_descriptor["datetime"], "hash": package_descriptor["hash"]}
@@ -78,36 +109,40 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     flow({
         "packages": [
-            # {
-            #     "package_path": "out/external_sharing/HASADNA/datapackage.json",
-            #     "publish_targets": [
-            #         {
-            #             "github_repo": "hasadna/avid-covider-raw-data",
-            #             "deploy_key": "hasadna_avid_covider_raw_data",
-            #             "branch": "testing",
-            #             "files": {
-            #                 "daily_summary": "input/{POSTERIOR_DATE}.csv",
-            #                 "cities_geojson": "geo/cities.geojson",
-            #                 "neighborhoods_geojson": "geo/neighborhoods.geojson"
-            #             }
-            #         }
-            #     ]
-            #
-            # },
             {
-                "package_path": "out/bayesian/idf/datapackage.json",
+                "package_path": "out/external_sharing/HASADNA/datapackage.json",
                 "publish_targets": [
                     {
-                        "github_repo": "hrossman/Covid19-Survey",
-                        "deploy_key": "hrossman_covid19_survey",
-                        "branch": "testing",
-                        "files_foreach": {
-                            "min_per_region_lst": {
-                                "min_per_region_{foreach_value}_html": "aggregated_data/{posterior_date}_min_per_region_{foreach_value}.html"
-                            }
+                        # "github_repo": "hasadna/avid-covider-raw-data",
+                        # "deploy_key": "hasadna_avid_covider_raw_data",
+                        # "branch": "testing",
+                        "zipfile": "data/maps_daily_summary_package.zip",
+                        "files": {
+                            "daily_summary": "input/{POSTERIOR_DATE}.csv",
+                            "all_dates": "input/all_dates.csv",
+                            "latest_ts": "input/ts.txt",
+                        },
+                        "file_contents": {
+                            "input/commit_id.txt": "{COVID19_ISRAEL_GITHUB_SHA1}"
                         }
                     }
                 ]
-            }
+
+            },
+            # {
+            #     "package_path": "out/bayesian/idf/datapackage.json",
+            #     "publish_targets": [
+            #         {
+            #             "github_repo": "hrossman/Covid19-Survey",
+            #             "deploy_key": "hrossman_covid19_survey",
+            #             "branch": "testing",
+            #             "files_foreach": {
+            #                 "min_per_region_lst": {
+            #                     "min_per_region_{foreach_value}_html": "aggregated_data/{posterior_date}_min_per_region_{foreach_value}.html"
+            #                 }
+            #             }
+            #         }
+            #     ]
+            # }
         ]
     }).process()

--- a/datapackage_pipelines_covid19israel/publish_external_sharing_packages.py
+++ b/datapackage_pipelines_covid19israel/publish_external_sharing_packages.py
@@ -7,6 +7,12 @@ import logging
 from avid_covider_pipelines.utils import get_hash, subprocess_call_log
 
 
+try:
+    from avid_covider_pipelines.run_covid19_israel import COVID19_ISRAEL_GITHUB_SHA1
+except ImportError:
+    COVID19_ISRAEL_GITHUB_SHA1 = "_"
+
+
 def flow(parameters, *_):
 
     def _process_packages():
@@ -17,6 +23,7 @@ def flow(parameters, *_):
                 resource["name"]: resource
                 for resource in package_descriptor["resources"]
             }
+            package_descriptor["COVID19_ISRAEL_GITHUB_SHA1"] = COVID19_ISRAEL_GITHUB_SHA1
             for publish_target in package["publish_targets"]:
                 assert "github_repo" in publish_target and "deploy_key" in publish_target and ("files" in publish_target or "files_foreach" in publish_target)
                 with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
PR contains several related changes:

* code running in covid19israel will be able to get the github sha1 from an env var: `os.environ.get("COVID19_ISRAEL_GITHUB_SHA1")`
* external sharing packages can write dynamic file contents based on package metadata, see comments in covid19israel.source-spec for details
* external sharing package metadata includes attribute `COVID19_ISRAEL_GITHUB_SHA1` for usage in dynamic file contents or other dynamic fields
* added files to maps daily summary external sharing: `input/ts.txt` and `input/commit_id.txt`